### PR TITLE
EVEREST-665 dev build fix

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - test
+      - main
 
 env:
   NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - test
 
 env:
   NODE_OPTIONS: "--max_old_space_size=4096"
@@ -39,7 +39,6 @@ jobs:
         run: |
           cd ui
           pnpm install
-          mkdir ${GITHUB_WORKSPACE}/public/dist/
           EVEREST_OUT_DIR=${GITHUB_WORKSPACE}/public/dist/ pnpm build
 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
As it turned out, there is no need at all for `mkdir` command in the FE build which I added to be sure that the directory exists. 
Without the `-p` option it fails in case the directory exists, so it's deleted 