### PR TITLE
EVEREST-726 use internal manifest

### DIFF
--- a/deploy/quickstart-k8s.yaml
+++ b/deploy/quickstart-k8s.yaml
@@ -53,7 +53,7 @@ roleRef:
 subjects:
   - kind: "ServiceAccount"
     name: everest-admin
-    namespace: percona-everest
+    namespace: everest-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,17 @@
+// Package scripts provides embed scripts.
+package scripts
+
+import "embed"
+
+//go:embed deploy/*
+var deployScripts embed.FS
+
+// Manifest returns Everest manifest file content.
+func Manifest() ([]byte, error) {
+	data, err := deployScripts.ReadFile("deploy/quickstart-k8s.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -47,7 +47,7 @@ type Install struct {
 }
 
 const (
-	everestBackendServiceName = "percona-everest-backend"
+	everestBackendServiceName = "everest"
 	everestOperatorName       = "everest-operator"
 	pxcOperatorName           = "percona-xtradb-cluster-operator"
 	psmdbOperatorName         = "percona-server-mongodb-operator"

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -25,7 +25,6 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -48,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
 
+	scripts "github.com/percona/everest"
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 	"github.com/percona/everest/data"
 	"github.com/percona/everest/pkg/kubernetes/client"
@@ -906,7 +906,7 @@ func (k *Kubernetes) ApplyObject(obj runtime.Object) error {
 
 // InstallEverest downloads the manifest file and applies it against provisioned k8s cluster.
 func (k *Kubernetes) InstallEverest(ctx context.Context, namespace string) error {
-	data, err := k.getManifestData()
+	data, err := scripts.Manifest()
 	if err != nil {
 		return errors.Join(err, errors.New("failed reading everest manifest file"))
 	}
@@ -921,17 +921,9 @@ func (k *Kubernetes) InstallEverest(ctx context.Context, namespace string) error
 	return nil
 }
 
-func (k *Kubernetes) getManifestData() ([]byte, error) {
-	data, err := os.ReadFile("deploy/quickstart-k8s.yaml")
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
-}
-
 // DeleteEverest downloads the manifest file and deletes it from provisioned k8s cluster.
 func (k *Kubernetes) DeleteEverest(_ context.Context, namespace string) error {
-	data, err := k.getManifestData()
+	data, err := scripts.Manifest()
 	if err != nil {
 		return errors.Join(err, errors.New("failed reading everest manifest file"))
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -26,7 +26,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -923,14 +922,7 @@ func (k *Kubernetes) InstallEverest(ctx context.Context, namespace string) error
 }
 
 func (k *Kubernetes) getManifestData() ([]byte, error) {
-	//take the absolute path to the running binary, like smth/everest/bin/everestctl
-	executablePath, err := os.Executable()
-	if err != nil {
-		return nil, err
-	}
-	// figuring out the root of the project, like smth/everest
-	root := filepath.Dir(filepath.Dir(executablePath))
-	data, err := os.ReadFile(filepath.Join(root, "/deploy/quickstart-k8s.yaml"))
+	data, err := os.ReadFile("deploy/quickstart-k8s.yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ var (
 	catalogImage string //nolint:gochecknoglobals
 )
 
-// CatalogImage returns a catalog image needed for the build of everestctl
+// CatalogImage returns a catalog image needed for the build of everestctl.
 func CatalogImage() string {
 	catalogImage = devCatalogImage
 	v, err := goversion.NewSemver(Version)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,8 +28,6 @@ import (
 const (
 	devCatalogImage     = "docker.io/perconalab/everest-catalog:latest"
 	releaseCatalogImage = "docker.io/percona/everest-catalog:%s"
-	devManifestURL      = "https://raw.githubusercontent.com/percona/percona-everest-backend/main/deploy/quickstart-k8s.yaml"
-	releaseManifestURL  = "https://raw.githubusercontent.com/percona/percona-everest-backend/v%s/deploy/quickstart-k8s.yaml"
 )
 
 var (
@@ -54,19 +52,6 @@ func CatalogImage() string {
 		catalogImage = fmt.Sprintf(releaseCatalogImage, Version)
 	}
 	return catalogImage
-}
-
-// ManifestURL returns a manifest URL to install everest
-//
-// for dev builds it returns everest-catalog:latest
-// for the release it returns everest-catalog:X.Y.Z.
-func ManifestURL() string {
-	url := devManifestURL
-	v, err := goversion.NewSemver(Version)
-	if Version != "" && err == nil && v.Prerelease() == "" {
-		url = fmt.Sprintf(releaseManifestURL, Version)
-	}
-	return url
 }
 
 // FullVersionInfo returns full version report.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -42,9 +42,6 @@ var (
 )
 
 // CatalogImage returns a catalog image needed for the build of everestctl
-//
-// for dev builds it returns https://raw.githubusercontent.com/percona/percona-everest-backend/main/deploy/quickstart-k8s.yaml
-// for the release builds it returns https://raw.githubusercontent.com/percona/percona-everest-backend/vX.Y.Z/deploy/quickstart-k8s.yaml
 func CatalogImage() string {
 	catalogImage = devCatalogImage
 	v, err := goversion.NewSemver(Version)


### PR DESCRIPTION
EVEREST-726 

Now the manifest file is in the same repo as the cli, so there is no need for the logic that differentiate the branches to pick up the manifest from.  