### PR TITLE
EVEREST-107 Add gatekeeper

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -447,19 +447,3 @@ jobs:
     secrets: inherit
     with:
       make_target: ${{ matrix.make_target }}
-
-  merge-gatekeeper:
-    needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests]
-    name: Merge Gatekeeper
-    if: ${{ always() }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Run Merge Gatekeeper
-        uses: upsidr/merge-gatekeeper@v1.2.1
-        with:
-          self: Merge Gatekeeper
-          token: ${{ secrets.GITHUB_TOKEN }}
-          interval: 45
-          timeout: 300
-          ignored: "license/snyk (Percona Github Org), security/snyk (Percona Github Org)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -447,3 +447,19 @@ jobs:
     secrets: inherit
     with:
       make_target: ${{ matrix.make_target }}
+
+  merge-gatekeeper:
+    needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests]
+    name: Merge Gatekeeper
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1.2.1
+        with:
+          self: Merge Gatekeeper
+          token: ${{ secrets.GITHUB_TOKEN }}
+          interval: 45
+          timeout: 300
+          ignored: "license/snyk (Percona Github Org), security/snyk (Percona Github Org)"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -449,7 +449,7 @@ jobs:
       make_target: ${{ matrix.make_target }}
 
   merge-gatekeeper:
-    needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests]
+    needs: [ test]
     name: Merge Gatekeeper
     if: ${{ always() }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -449,7 +449,7 @@ jobs:
       make_target: ${{ matrix.make_target }}
 
   merge-gatekeeper:
-    needs: [ test]
+    needs: [ test, check, integration_tests_api, integration_tests_flows]
     name: Merge Gatekeeper
     if: ${{ always() }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -449,7 +449,7 @@ jobs:
       make_target: ${{ matrix.make_target }}
 
   merge-gatekeeper:
-    needs: [ test, check, integration_tests_api, integration_tests_flows]
+    needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests_cli]
     name: Merge Gatekeeper
     if: ${{ always() }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/dev-fe-ci.yaml
+++ b/.github/workflows/dev-fe-ci.yaml
@@ -239,20 +239,3 @@ jobs:
         if: ${{ failure() }}
         run: |
           kubectl -n everest-system logs deployment/percona-everest
-
-
-  merge-gatekeeper:
-    needs: [ CI_checks, E2E ]
-    name: Merge Gatekeeper
-    if: ${{ always() }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Run Merge Gatekeeper
-        uses: upsidr/merge-gatekeeper@v1.2.1
-        with:
-          self: Merge Gatekeeper
-          token: ${{ secrets.GITHUB_TOKEN }}
-          interval: 45
-          timeout: 300
-          ignored: "license/snyk (Percona Github Org), security/snyk (Percona Github Org)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/dev-fe-ci.yaml
+++ b/.github/workflows/dev-fe-ci.yaml
@@ -239,3 +239,20 @@ jobs:
         if: ${{ failure() }}
         run: |
           kubectl -n everest-system logs deployment/percona-everest
+
+
+  merge-gatekeeper:
+    needs: [ CI_checks, E2E ]
+    name: Merge Gatekeeper
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1.2.1
+        with:
+          self: Merge Gatekeeper
+          token: ${{ secrets.GITHUB_TOKEN }}
+          interval: 45
+          timeout: 300
+          ignored: "license/snyk (Percona Github Org), security/snyk (Percona Github Org)"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ You can visit http://127.0.0.1:8080 to create your first database cluster!
     * [Nginx](https://www.nginx.com) via
   [Authentication Based on Subrequest Result](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/)
 
-A change to revert
+A change to revert 1

--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ You can visit http://127.0.0.1:8080 to create your first database cluster!
   [Custom Authorizers](https://aws.amazon.com/de/blogs/compute/introducing-custom-authorizers-in-amazon-api-gateway/)
     * [Nginx](https://www.nginx.com) via
   [Authentication Based on Subrequest Result](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/)
+
+A change to revert

--- a/README.md
+++ b/README.md
@@ -59,5 +59,3 @@ You can visit http://127.0.0.1:8080 to create your first database cluster!
   [Custom Authorizers](https://aws.amazon.com/de/blogs/compute/introducing-custom-authorizers-in-amazon-api-gateway/)
     * [Nginx](https://www.nginx.com) via
   [Authentication Based on Subrequest Result](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/)
-
-A change to revert 2

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ You can visit http://127.0.0.1:8080 to create your first database cluster!
     * [Nginx](https://www.nginx.com) via
   [Authentication Based on Subrequest Result](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/)
 
-A change to revert 1
+A change to revert 2


### PR DESCRIPTION
**Problem** 
Need to set the different sets of checks for FE and API+CLI as required (to block PR merge if smth is failed). 
GitHub doesn't allow to set the required checks conditionally.

**Solution**
Use merge-gatekeeper github action. It fails if any of the configured checks are failed, so it's added to both API+CLI and UI CI and now we can make only the gatekeeper check as required. [Here](https://github.com/percona/everest/actions/runs/8143600237?pr=30) is how it looks like

**Action needed after merge:**
set "Merge Gatekeeper" check as required