### PR TITLE
EVEREST-107 FE checks for FE CI file

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -4,11 +4,13 @@ on:
   push:
     paths-ignore:
       - 'ui/**'
+      - '.github/workflows/dev-fe-ci.yaml'
     branches:
       - main
   pull_request:
     paths-ignore:
       - 'ui/**'
+      - '.github/workflows/dev-fe-ci.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/dev-fe-ci.yaml
+++ b/.github/workflows/dev-fe-ci.yaml
@@ -4,11 +4,14 @@ on:
   push:
     paths:
       - 'ui/**'
+      - '.github/workflows/dev-fe-ci.yaml'
     branches:
       - main
   pull_request:
     paths:
       - 'ui/**'
+      - '.github/workflows/dev-fe-ci.yaml'
+
 
 permissions:
   contents: read


### PR DESCRIPTION
**Problem**
FE CI is not being triggered when there are changes in the `dev-fe-ci.yaml` file, although the FE CI is impacted. 
From the other side, the changes don’t impact the BE part at all, but all the BE/CLI checks are being triggered. 

**Solution**
Don't run BE CI for the `dev-fe-ci.yaml` file changes but run the FE CI in such case. 