### PR TITLE
EVEREST-107 remove pod anti-affinity rules

### DIFF
--- a/deploy/quickstart-k8s.yaml
+++ b/deploy/quickstart-k8s.yaml
@@ -93,14 +93,6 @@ spec:
     spec:
       serviceAccountName: everest-admin
       automountServiceAccountToken: true
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/component: everest
-                app.kubernetes.io/name: everest
-            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: everest
           image: perconalab/everest:0.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.22.0
 	github.com/operator-framework/operator-lifecycle-manager v0.26.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240319093206-a178f0ebc9cd
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240320152933-9a3a67f1da9f
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240319093206-a178f0ebc9cd h1:RGFjt38+CUBSDj6m0pEHUYIdQnXUMUR7nF3RZbsdua4=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240319093206-a178f0ebc9cd/go.mod h1:SFW6rfk9hSc/A+d0lUlmC9tYpSd6RW9nP2cVs6kjbZw=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240320152933-9a3a67f1da9f h1:gZX+0G5kYC3lLDccAjkMTtTaSnyoXp/WprD7woNinWs=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240320152933-9a3a67f1da9f/go.mod h1:SFW6rfk9hSc/A+d0lUlmC9tYpSd6RW9nP2cVs6kjbZw=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=


### PR DESCRIPTION
We don't really need pod anti-affinity rules. We only run a single replica so the high-availability is clearly not a concern right now. Also users that are testing out everest on single node clusters wouldn't be able to upgrade everest due to this constraint.