### PR TITLE
[UI] EVEREST-926 Fix 'Add storage' dialog width

### DIFF
--- a/ui/apps/everest/src/pages/settings/storage-locations/createEditModal/create-edit-modal.tsx
+++ b/ui/apps/everest/src/pages/settings/storage-locations/createEditModal/create-edit-modal.tsx
@@ -44,6 +44,7 @@ export const CreateEditModalStorage = ({
 
   return (
     <FormDialog
+      size="XL"
       isOpen={open}
       closeModal={handleCloseModal}
       submitting={isLoading}


### PR DESCRIPTION
[EVEREST-926](https://perconadev.atlassian.net/browse/EVEREST-926)

<img width="1792" alt="image" src="https://github.com/percona/everest/assets/79999411/1f7dc578-ce91-4625-b8f0-164278a943bd">

<img width="1792" alt="image" src="https://github.com/percona/everest/assets/79999411/fa2d5182-ae89-4ce9-9aa0-a364f36827b2">


[EVEREST-926]: https://perconadev.atlassian.net/browse/EVEREST-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ