### PR TITLE
EVEREST-107 put requests metadata validation

### DIFF
--- a/.github/workflows/dev-fe-ci.yaml
+++ b/.github/workflows/dev-fe-ci.yaml
@@ -100,7 +100,6 @@ jobs:
         if: steps.check_changes.outputs.changes == 'true' && github.event_name == 'pull_request'
         with:
           commit_message: 'chore: lint/format'
-          token: ${{ secrets.ROBOT_TOKEN }}
 
   E2E:
     name: E2E Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,3 @@ kubectl -n namespace logs <podname>  # Check logs for a pod
 ```
 kubectl -n namespace get pvc  # PVCs should be Bound
 ```
-
-
-
-            change to revert

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,3 +98,7 @@ kubectl -n namespace logs <podname>  # Check logs for a pod
 ```
 kubectl -n namespace get pvc  # PVCs should be Bound
 ```
+
+
+
+            change to revert


### PR DESCRIPTION
EVEREST-107 fix FE CI

Previously the `stefanzweifel/git-auto-commit-action@v5` was fine with unexisting (as it turned out) parameter, but at some point it's not anymore. So deleted the parameter. The CI checks are passing.