### PR TITLE
[UI] EVEREST-948 Actionable Alert button is not visible in dark theme

### DIFF
--- a/ui/apps/everest/src/components/actionable-alert/ActionableAlert.tsx
+++ b/ui/apps/everest/src/components/actionable-alert/ActionableAlert.tsx
@@ -11,7 +11,12 @@ const ActionableAlert = ({
   <Alert
     severity="warning"
     action={
-      <Button color="inherit" size="small" onClick={onClick} {...buttonProps}>
+      <Button
+        sx={{ color: 'warning.contrastText', fontWeight: 600 }}
+        size="small"
+        onClick={onClick}
+        {...buttonProps}
+      >
         {buttonMessage || 'Add'}
       </Button>
     }


### PR DESCRIPTION
[EVEREST-948](https://perconadev.atlassian.net/browse/EVEREST-948)
<img width="1693" alt="Screenshot 2024-04-02 at 12 56 23" src="https://github.com/percona/everest/assets/79999411/c288608a-af91-48ea-942e-7e401306e12d">
<img width="1674" alt="image" src="https://github.com/percona/everest/assets/79999411/d0bad050-a17f-4981-a910-d342a65d9303">


[EVEREST-948]: https://perconadev.atlassian.net/browse/EVEREST-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ