### PR TITLE
[UI] EVEREST-954 Invert tooltip colors dark mode & light mode

### DIFF
--- a/ui/packages/design/src/themes/base/BaseTheme.tsx
+++ b/ui/packages/design/src/themes/base/BaseTheme.tsx
@@ -29,6 +29,10 @@ declare module '@mui/material/styles' {
       dividerStronger?: string;
       contour?: string;
     };
+    tooltips?: {
+      color?: string;
+      background?: string;
+    };
   }
 
   interface Palette extends PaletteOptions {}
@@ -158,6 +162,10 @@ const baseThemeOptions = (mode: PaletteMode): ThemeOptions => ({
             dividerStronger: '#2C323E',
             contour: 'rgba(0, 0, 0, 0.06)',
           },
+          tooltips: {
+            background: '#3A4151',
+            color: '#FFFFFF',
+          },
         }
       : {
           default: {
@@ -222,6 +230,10 @@ const baseThemeOptions = (mode: PaletteMode): ThemeOptions => ({
             dividerStrong: 'rgba(209, 213, 222, 0.5)',
             dividerStronger: '#FFFFFF',
             contour: 'rgba(255, 255, 255, 0.08)',
+          },
+          tooltips: {
+            background: '#F0F1F4',
+            color: '#2C323E',
           },
         }),
   },
@@ -603,15 +615,14 @@ const baseThemeOptions = (mode: PaletteMode): ThemeOptions => ({
         tooltip: ({ theme }) => ({
           ...theme.typography.helperText,
           boxShadow: theme.shadows[8],
-          color: theme.palette.text.primary,
-          ...(theme.palette.surfaces && {
-            backgroundColor:
-              theme.palette.surfaces[mode == 'light' ? 'low' : 'high'],
+          ...(theme.palette.tooltips && {
+            color: theme.palette.tooltips?.color,
+            backgroundColor: theme.palette.tooltips?.background,
           }),
         }),
         arrow: ({ theme }) => ({
-          ...(theme.palette.surfaces && {
-            color: theme.palette.surfaces[mode == 'light' ? 'low' : 'high'],
+          ...(theme.palette.tooltips && {
+            color: theme.palette.tooltips?.background,
           }),
         }),
       },


### PR DESCRIPTION
[EVEREST-954](https://perconadev.atlassian.net/browse/EVEREST-954)


No arrow:

<img width="1672" alt="Screenshot 2024-04-04 at 15 53 18" src="https://github.com/percona/everest/assets/79999411/5fb897f8-448e-4258-b749-7b2c229dccf5">
<img width="1673" alt="Screenshot 2024-04-04 at 15 53 30" src="https://github.com/percona/everest/assets/79999411/88156ba5-8aaf-4f80-b71a-f4bfb1a48f36">


With arrow: 
<img width="1668" alt="Screenshot 2024-04-04 at 15 56 39" src="https://github.com/percona/everest/assets/79999411/b2549554-6517-4f67-ab55-62f72bb8d136">
<img width="1689" alt="Screenshot 2024-04-04 at 15 56 45" src="https://github.com/percona/everest/assets/79999411/81d074c5-fc97-4969-8a79-7881aeeeb0ac">
