### PR TITLE
[UI] EVEREST-940 Open Documentation link on PITR in new tab

### DIFF
--- a/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal.tsx
+++ b/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal.tsx
@@ -220,11 +220,15 @@ const RestoreDbModal = <T extends FieldValues>({
                     sx={{ mt: 1.5 }}
                     message={Messages.pitrLimitationAlert}
                     buttonMessage={Messages.seeDocs}
+                    onClick={() =>
+                      window.open(
+                        'https://docs.percona.com/everest/use/createBackups/EnablePITR.html#limitation',
+                        '_blank',
+                        'noopener'
+                      )
+                    }
                     buttonProps={{
-                      href: 'https://docs.percona.com/everest/use/createBackups/EnablePITR.html#limitation',
-                      sx: {
-                        whiteSpace: 'nowrap',
-                      },
+                      sx: { whiteSpace: 'nowrap' },
                     }}
                   />
                 )}

--- a/ui/apps/everest/src/pages/databases/lastBackup/LastBackup.tsx
+++ b/ui/apps/everest/src/pages/databases/lastBackup/LastBackup.tsx
@@ -25,6 +25,7 @@ export const LastBackup = ({ dbName, namespace }: LastBackupProps) => {
             <Tooltip
               title={Messages.lastBackup.warningTooltip}
               placement="right"
+              arrow
             >
               <IconButton>
                 <WarningIcon />


### PR DESCRIPTION
[EVEREST-940](https://perconadev.atlassian.net/browse/EVEREST-940)


Also added arrow for warning icon
<img width="1688" alt="Screenshot 2024-04-08 at 15 47 29" src="https://github.com/percona/everest/assets/79999411/6318dbb1-af5a-420a-a634-1e2eca94ac32">


[EVEREST-940]: https://perconadev.atlassian.net/browse/EVEREST-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ