### PR TITLE
EVEREST-964 increase default rate limit

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -49,7 +49,7 @@ type EverestConfig struct {
 	// DisableTelemetry disable Everest and the upstream operators telemetry
 	DisableTelemetry bool `default:"false" envconfig:"DISABLE_TELEMETRY"`
 	// APIRequestsRateLimit allowed amount of API requests per second
-	APIRequestsRateLimit int `default:"20" envconfig:"API_REQUESTS_RATE_LIMIT"`
+	APIRequestsRateLimit int `default:"100" envconfig:"API_REQUESTS_RATE_LIMIT"`
 }
 
 // ParseConfig parses env vars and fills EverestConfig.


### PR DESCRIPTION
EVEREST-964 

As discussed during the demo, increases the default rate limit to 100 requests per second considering how many requests does the FE do and the fact that with bigger amount of databases the end users may run into rate limiting problems soon. 