### PR TITLE
EVEREST-976 | allow updating DBEngine version

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -908,6 +908,11 @@ func validateDBEngineVersionUpgrade(newVersion, oldVersion string) error {
 		return fmt.Errorf("invalid version %s", newVersion)
 	}
 	// We will not allow major upgrades.
+	// Major upgrades are handled differently for different operators, so for now we simply won't allow it.
+	// For example:
+	// - PXC operator allows major upgrades.
+	// - PSMDB operator allows major upgrades, but we need to handle FCV.
+	// - PG operator does not allow major upgrades.
 	if semver.Major(oldVersion) != semver.Major(newVersion) {
 		return fmt.Errorf("cannot upgrade from %s to %s", oldVersion, newVersion)
 	}

--- a/api/validation.go
+++ b/api/validation.go
@@ -927,10 +927,10 @@ func validateDBEngineVersionUpgrade(newVersion, oldVersion string) error {
 }
 
 func validateDatabaseClusterOnUpdate(dbc *DatabaseCluster, oldDB *everestv1alpha1.DatabaseCluster) error {
-	newVersion := "v" + pointer.Get(dbc.Spec.Engine.Version)
-	oldVersion := "v" + oldDB.Spec.Engine.Version
+	newVersion := pointer.Get(dbc.Spec.Engine.Version)
+	oldVersion := oldDB.Spec.Engine.Version
 	if newVersion != "" && newVersion != oldVersion {
-		if err := validateDBEngineVersionUpgrade(newVersion, oldVersion); err != nil {
+		if err := validateDBEngineVersionUpgrade("v"+newVersion, "v"+oldVersion); err != nil {
 			return err
 		}
 	}

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -974,24 +974,30 @@ func TestValidateDBEngineUpgrade(t *testing.T) {
 	}{
 		{
 			name:       "invalid version",
-			oldVersion: "v1.0.0",
+			oldVersion: "1.0.0",
 			newVersion: "1!00;",
 			err:        errInvalidVersion,
 		},
 		{
 			name:       "major upgrade",
-			oldVersion: "v8.0.22",
-			newVersion: "v9.0.0",
+			oldVersion: "8.0.22",
+			newVersion: "9.0.0",
 			err:        errDBEngineMajorVersionUpgrade,
 		},
 		{
 			name:       "downgrade",
-			oldVersion: "v8.0.22",
-			newVersion: "v8.0.21",
+			oldVersion: "8.0.22",
+			newVersion: "8.0.21",
 			err:        errDBEngineDowngrade,
 		},
 		{
 			name:       "valid upgrade",
+			oldVersion: "8.0.22",
+			newVersion: "8.0.23",
+			err:        nil,
+		},
+		{
+			name:       "valid upgrade (with 'v' prefix)",
 			oldVersion: "v8.0.22",
 			newVersion: "v8.0.23",
 			err:        nil,

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -963,3 +963,45 @@ func TestValidateBucketName(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDBEngineUpgrade(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name       string
+		oldVersion string
+		newVersion string
+		err        error
+	}{
+		{
+			name:       "invalid version",
+			oldVersion: "v1.0.0",
+			newVersion: "1!00;",
+			err:        errInvalidVersion,
+		},
+		{
+			name:       "major upgrade",
+			oldVersion: "v8.0.22",
+			newVersion: "v9.0.0",
+			err:        errDBEngineMajorVersionUpgrade,
+		},
+		{
+			name:       "downgrade",
+			oldVersion: "v8.0.22",
+			newVersion: "v8.0.21",
+			err:        errDBEngineDowngrade,
+		},
+		{
+			name:       "valid upgrade",
+			oldVersion: "v8.0.22",
+			newVersion: "v8.0.23",
+			err:        nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDBEngineVersionUpgrade(tc.newVersion, tc.oldVersion)
+			assert.ErrorIs(t, err, tc.err)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.22.0
+	golang.org/x/mod v0.15.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/time v0.5.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -142,7 +143,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
-	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect


### PR DESCRIPTION
### Description

This PR adds the ability to edit/update the database server (engine) version. This is required as a part of the components upgrade feature. However, the following restrictions will apply:

- Prevent downgrades
- Prevent major version upgrades (since they're handled differently for different operators)

TODO:
- Allow updating this version from the UI