### PR TITLE
EVEREST-980 | (Bug fix) Ensure install approves the correct InstallPlan

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -633,8 +633,12 @@ func (k *Kubernetes) InstallOperator(ctx context.Context, req InstallOperatorReq
 			return false, nil
 		}
 		installPlanName := subs.Status.InstallPlanRef.Name
-		if req.StartingCSV != "" {
-			ip, err := k.getInstallPlanForCSV(ctx, req.StartingCSV, req.Namespace)
+		targetCSV := req.StartingCSV
+		if subs.Status.CurrentCSV != "" {
+			targetCSV = subs.Status.CurrentCSV
+		}
+		if targetCSV != "" {
+			ip, err := k.getInstallPlanForCSV(ctx, targetCSV, req.Namespace)
 			if err != nil {
 				return false, errors.Join(err, fmt.Errorf("cannot get install plan for CSV: %q", req.StartingCSV))
 			}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -570,8 +570,8 @@ func mergeSubscriptionConfig(sub *olmv1alpha1.SubscriptionConfig, cfg *olmv1alph
 
 func (k *Kubernetes) getTargetInstallPlanName(ctx context.Context, subscription *olmv1alpha1.Subscription, req InstallOperatorRequest) (string, error) {
 	targetCSV := req.StartingCSV
-	if subscription.Status.CurrentCSV != "" {
-		targetCSV = subscription.Status.CurrentCSV
+	if subscription.Status.InstalledCSV != "" {
+		targetCSV = subscription.Status.InstalledCSV
 	}
 	if targetCSV == "" {
 		// We don't know yet which CSV we want, so we will use the one specified in the subscription.

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -574,7 +574,7 @@ func (k *Kubernetes) getTargetInstallPlanName(ctx context.Context, subscription 
 		targetCSV = subscription.Status.CurrentCSV
 	}
 	if targetCSV == "" {
-		// We don't have a targetCSV, so we use the InstallPlan that points to the starting CSV.
+		// We don't know yet which CSV we want, so we will use the one specified in the subscription.
 		return subscription.Status.InstallPlanRef.Name, nil
 	}
 	ipList, err := k.client.ListInstallPlans(ctx, req.Namespace)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -629,7 +629,7 @@ func (k *Kubernetes) InstallOperator(ctx context.Context, req InstallOperatorReq
 		if err != nil {
 			return false, errors.Join(err, fmt.Errorf("cannot get an install plan for the operator subscription: %q", req.Name))
 		}
-		if subs == nil || (subs != nil && subs.Status.InstallPlanRef == nil) {
+		if subs == nil || subs.Status.InstallPlanRef == nil {
 			return false, nil
 		}
 		installPlanName := subs.Status.InstallPlanRef.Name

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -632,12 +632,16 @@ func (k *Kubernetes) InstallOperator(ctx context.Context, req InstallOperatorReq
 		if subs == nil || subs.Status.InstallPlanRef == nil {
 			return false, nil
 		}
+
 		installPlanName := subs.Status.InstallPlanRef.Name
+
+		// We use the current CSV if available, otherwise we use the starting CSV.
 		targetCSV := req.StartingCSV
 		if subs.Status.CurrentCSV != "" {
 			targetCSV = subs.Status.CurrentCSV
 		}
 		if targetCSV != "" {
+			// If we have a targetCSV, we use the InstallPlan that points to it.
 			ip, err := k.getInstallPlanForCSV(ctx, targetCSV, req.Namespace)
 			if err != nil {
 				return false, errors.Join(err, fmt.Errorf("cannot get install plan for CSV: %q", req.StartingCSV))

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -588,7 +588,7 @@ func (k *Kubernetes) getTargetInstallPlanName(ctx context.Context, subscription 
 			}
 		}
 	}
-	return "", fmt.Errorf("cannot find InstallPlan for CSV: %q", targetCSV)
+	return "", fmt.Errorf("cannot find InstallPlan for CSV: %s", targetCSV)
 }
 
 // InstallOperator installs an operator via OLM.


### PR DESCRIPTION
## Problem

Currently, `install` approves the `InstallPlanRef` from the the Subscription, which may change over time (because of OLM). This means that running `install` twice can result in the installation of an undesired operator version (CSV).

## Solution

- We use the `installedCSV` from the Subscription status
- During the first installation, `installedCSV` is empty, so we take `startingCSV`
- `startingCSV` may be unspecified since it is optional, then we take the `InstallPlanRef`