### PR TITLE
EVEREST-107 Remove index.html

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -69,6 +69,9 @@ jobs:
       - name: Download Go modules
         run: go mod download
 
+      - name: Create index.html file
+        run: mkdir public/dist && touch public/dist/index.html
+
       - name: Install development tools
         run: make init
 
@@ -161,6 +164,9 @@ jobs:
 
       - name: Download Go modules
         run: go mod download
+
+      - name: Create index.html file
+        run: mkdir public/dist && touch public/dist/index.html
 
       - name: Install tools
         run: make init
@@ -260,6 +266,9 @@ jobs:
       - name: Expose local registry
         run: |
           kubectl port-forward --namespace kube-system service/registry 5000:80 &
+
+      - name: Create index.html file
+        run: mkdir public/dist && touch public/dist/index.html
 
       - name: Build Everest API Server
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 api_tests/node_modules/*
 cmd/cmd
 
-public/
+public/dist/


### PR DESCRIPTION
We don't want to version control this file because it has no meaning and will always be overwritten by the build process. It only existed so that one doesn't have to build the UI to run the API server. By creating it in the CI workflows we can run the BE CI pipelines without needing to have it in git.