### PR TITLE
EVEREST-107 update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,15 +74,15 @@ jobs:
           # update version in the Makefile
           sed -i "s/^VERSION ?=.*/VERSION ?= $VERSION/g" Makefile
 
-          make init
-          make release
-
           # if there is something to commit, commit it and add the tag
           if [[ -n $(git status --porcelain) ]]; then
             if git tag --list | grep -q "^$GH_TAG$"; then
               echo "The tag is already present in github. Please create a different RC/Release"
               exit 1
             fi
+          
+            make init
+            make release
 
             # configure userdata for commits
             git config --global user.email "everest-ci@percona.com"
@@ -94,6 +94,8 @@ jobs:
 
             git tag $GH_TAG
             git push origin $GH_TAG
+          else
+            echo "No need for a new build"
           fi
 
 
@@ -243,7 +245,7 @@ jobs:
           git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
 
           # Check if veneer has the new version listed
-          if grep -q "$VERSION" catalog/everest-operator/catalog.yaml; then
+          if ! grep -q "$VERSION" catalog/everest-operator/catalog.yaml; then
             echo "catalog/everest-operator/catalog.yaml does not include the version $VERSION"
             echo "Update the file manually before running the workflow"
             exit 1


### PR DESCRIPTION
EVEREST-107

During the RC for `0.10.0-rc3` there are discovered a couple of problems:
1. Inverted condition that checks mentions of the version in the catalog
2. For the operator the `make release` command always generates changes bc the date changes. So moved the `make release` so that on the second run with the same tag it wouldn't generate any changes. 

Both changes are related to [the temporary process](https://github.com/percona/everest/pull/226#discussion_r1574756469) for the RC/Release we agreed to have until it's automated 