### PR TITLE
EVEREST-964 | Add label drop for GKE clusters

### DIFF
--- a/data/crds/victoriametrics/crs/vmnodescrape-cadvisor.yaml
+++ b/data/crds/victoriametrics/crs/vmnodescrape-cadvisor.yaml
@@ -26,6 +26,8 @@ spec:
       targetLabel: __metrics_path__
       replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
   metricRelabelConfigs:
+  - action: labeldrop
+    regex: cloud_google_com.*
   - source_labels:
     - namespace
     - pod

--- a/data/crds/victoriametrics/crs/vmnodescrape-kubelet.yaml
+++ b/data/crds/victoriametrics/crs/vmnodescrape-kubelet.yaml
@@ -19,6 +19,8 @@ spec:
     regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
     source_labels:
     - __name__
+  - action: labeldrop
+    regex: cloud_google_com.*
   relabelConfigs:
   - action: labelmap
     regex: __meta_kubernetes_node_label_(.+)


### PR DESCRIPTION
## Problem
Nodes and resources in GKE have a lot of labels that google cloud provides by default.With the current configuration, VM scrapes them all.

PMM is limited to have 30 labels only so as a result some labels that we care about (like k8s_cluster_id) are not there thus the PMM dashboard does not fully work.

## Solution

Add a label drop for GKE related labels.

