### PR TITLE
EVEREST-1003 | install: improve Everest restart logic

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -28,6 +28,8 @@ const (
 	SystemNamespace = "everest-system"
 	// PerconaEverestDeploymentName stores the name of everest API Server deployment.
 	PerconaEverestDeploymentName = "percona-everest"
+	// PerconaEverestOperatorDeploymentName stores the name of everest operator deployment.
+	PerconaEverestOperatorDeploymentName = "everest-operator-controller-manager"
 	// EverestContainerNameInDeployment is the name of the Everest container in the deployment.
 	EverestContainerNameInDeployment = "everest"
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -58,9 +58,8 @@ type Install struct {
 }
 
 const (
-	everestBackendServiceName = "everest"
-	vmOperatorName            = "victoriametrics-operator"
-	operatorInstallThreads    = 1
+	vmOperatorName         = "victoriametrics-operator"
+	operatorInstallThreads = 1
 
 	everestServiceAccount                   = "everest-admin"
 	everestServiceAccountRole               = "everest-admin-role"
@@ -374,10 +373,10 @@ func (o *Install) provisionEverest(ctx context.Context, v *goversion.Version) er
 		}
 	} else {
 		o.l.Info("Restarting Everest")
-		if err := o.kubeClient.RestartDeployment(ctx, common.EverestOperatorName, common.SystemNamespace); err != nil {
+		if err := o.kubeClient.RestartOperator(ctx, common.PerconaEverestOperatorDeploymentName, common.SystemNamespace); err != nil {
 			return err
 		}
-		if err := o.kubeClient.RestartDeployment(ctx, everestBackendServiceName, common.SystemNamespace); err != nil {
+		if err := o.kubeClient.RestartDeployment(ctx, common.PerconaEverestDeploymentName, common.SystemNamespace); err != nil {
 			return err
 		}
 	}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -374,10 +374,10 @@ func (o *Install) provisionEverest(ctx context.Context, v *goversion.Version) er
 		}
 	} else {
 		o.l.Info("Restarting Everest")
-		if err := o.kubeClient.RestartEverest(ctx, common.EverestOperatorName, common.SystemNamespace); err != nil {
+		if err := o.kubeClient.RestartDeployment(ctx, common.EverestOperatorName, common.SystemNamespace); err != nil {
 			return err
 		}
-		if err := o.kubeClient.RestartEverest(ctx, everestBackendServiceName, common.SystemNamespace); err != nil {
+		if err := o.kubeClient.RestartDeployment(ctx, everestBackendServiceName, common.SystemNamespace); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -1347,6 +1347,14 @@ func (c *Client) ListClusterServiceVersion(
 	return c.olmClientset.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
 }
 
+// UpdateClusterServiceVersion updates a CSV and returns the updated CSV.
+func (c *Client) UpdateClusterServiceVersion(
+	ctx context.Context,
+	csv *v1alpha1.ClusterServiceVersion,
+) (*v1alpha1.ClusterServiceVersion, error) {
+	return c.olmClientset.OperatorsV1alpha1().ClusterServiceVersions(csv.Namespace).Update(ctx, csv, metav1.UpdateOptions{})
+}
+
 // DeleteClusterServiceVersion deletes a CSV by namespaced name.
 func (c *Client) DeleteClusterServiceVersion(
 	ctx context.Context,

--- a/pkg/kubernetes/client/deployment.go
+++ b/pkg/kubernetes/client/deployment.go
@@ -22,3 +22,8 @@ func (c *Client) ListDeployments(ctx context.Context, namespace string) (*appsv1
 	}
 	return c.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
 }
+
+// UpdateDeployment updates a deployment and returns the updated object.
+func (c *Client) UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	return c.clientset.AppsV1().Deployments(deployment.GetNamespace()).Update(ctx, deployment, metav1.UpdateOptions{})
+}

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -105,6 +105,8 @@ type KubeClientConnector interface {
 	GetClusterServiceVersion(ctx context.Context, key types.NamespacedName) (*v1alpha1.ClusterServiceVersion, error)
 	// ListClusterServiceVersion list all CSVs for the given namespace.
 	ListClusterServiceVersion(ctx context.Context, namespace string) (*v1alpha1.ClusterServiceVersionList, error)
+	// UpdateClusterServiceVersion updates a CSV and returns the updated CSV.
+	UpdateClusterServiceVersion(ctx context.Context, csv *v1alpha1.ClusterServiceVersion) (*v1alpha1.ClusterServiceVersion, error)
 	// DeleteClusterServiceVersion deletes a CSV by namespaced name.
 	DeleteClusterServiceVersion(ctx context.Context, key types.NamespacedName) error
 	// DeleteFile accepts manifest file contents parses into []runtime.Object

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -138,6 +138,8 @@ type KubeClientConnector interface {
 	GetDeployment(ctx context.Context, name string, namespace string) (*appsv1.Deployment, error)
 	// ListDeployments returns deployment by name.
 	ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error)
+	// UpdateDeployment updates a deployment and returns the updated object.
+	UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error)
 	// GetInstallPlan retrieves an OLM install plan by namespace and name.
 	GetInstallPlan(ctx context.Context, namespace string, name string) (*v1alpha1.InstallPlan, error)
 	// ListInstallPlans lists install plans.

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -1817,6 +1817,36 @@ func (_m *MockKubeClientConnector) UpdateBackupStorage(ctx context.Context, stor
 	return r0
 }
 
+// UpdateClusterServiceVersion provides a mock function with given fields: ctx, csv
+func (_m *MockKubeClientConnector) UpdateClusterServiceVersion(ctx context.Context, csv *operatorsv1alpha1.ClusterServiceVersion) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	ret := _m.Called(ctx, csv)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateClusterServiceVersion")
+	}
+
+	var r0 *operatorsv1alpha1.ClusterServiceVersion
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *operatorsv1alpha1.ClusterServiceVersion) (*operatorsv1alpha1.ClusterServiceVersion, error)); ok {
+		return rf(ctx, csv)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *operatorsv1alpha1.ClusterServiceVersion) *operatorsv1alpha1.ClusterServiceVersion); ok {
+		r0 = rf(ctx, csv)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operatorsv1alpha1.ClusterServiceVersion)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *operatorsv1alpha1.ClusterServiceVersion) error); ok {
+		r1 = rf(ctx, csv)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateDatabaseClusterBackup provides a mock function with given fields: ctx, backup
 func (_m *MockKubeClientConnector) UpdateDatabaseClusterBackup(ctx context.Context, backup *v1alpha1.DatabaseClusterBackup) (*v1alpha1.DatabaseClusterBackup, error) {
 	ret := _m.Called(ctx, backup)

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -1877,6 +1877,36 @@ func (_m *MockKubeClientConnector) UpdateDatabaseEngine(ctx context.Context, nam
 	return r0, r1
 }
 
+// UpdateDeployment provides a mock function with given fields: ctx, deployment
+func (_m *MockKubeClientConnector) UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	ret := _m.Called(ctx, deployment)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateDeployment")
+	}
+
+	var r0 *appsv1.Deployment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *appsv1.Deployment) (*appsv1.Deployment, error)); ok {
+		return rf(ctx, deployment)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *appsv1.Deployment) *appsv1.Deployment); ok {
+		r0 = rf(ctx, deployment)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*appsv1.Deployment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *appsv1.Deployment) error); ok {
+		r1 = rf(ctx, deployment)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateInstallPlan provides a mock function with given fields: ctx, namespace, installPlan
 func (_m *MockKubeClientConnector) UpdateInstallPlan(ctx context.Context, namespace string, installPlan *operatorsv1alpha1.InstallPlan) (*operatorsv1alpha1.InstallPlan, error) {
 	ret := _m.Called(ctx, namespace, installPlan)

--- a/pkg/kubernetes/deployment.go
+++ b/pkg/kubernetes/deployment.go
@@ -10,3 +10,7 @@ import (
 func (k *Kubernetes) GetDeployment(ctx context.Context, name, namespace string) (*appsv1.Deployment, error) {
 	return k.client.GetDeployment(ctx, name, namespace)
 }
+
+func (k *Kubernetes) UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	return k.client.UpdateDeployment(ctx, deployment)
+}

--- a/pkg/kubernetes/deployment.go
+++ b/pkg/kubernetes/deployment.go
@@ -11,6 +11,7 @@ func (k *Kubernetes) GetDeployment(ctx context.Context, name, namespace string) 
 	return k.client.GetDeployment(ctx, name, namespace)
 }
 
+// UpdateDeployment updates a deployment and returns the updated object.
 func (k *Kubernetes) UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
 	return k.client.UpdateDeployment(ctx, deployment)
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -98,14 +98,10 @@ const (
 	pollDuration = 300 * time.Second
 
 	deploymentRestartAnnotation = "kubectl.kubernetes.io/restartedAt"
-	csvOperatorNameKeyTmpl      = "operators.coreos.com/%s.%s"
 )
 
-var (
-	// ErrEmptyVersionTag Got an empty version tag from GitHub API.
-	ErrEmptyVersionTag       = errors.New("got an empty version tag from Github")
-	errNoEverestOperatorPods = errors.New("no instances of everest-operator are running")
-)
+// ErrEmptyVersionTag Got an empty version tag from GitHub API.
+var ErrEmptyVersionTag = errors.New("got an empty version tag from Github")
 
 // Kubernetes is a client for Kubernetes.
 type Kubernetes struct {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -854,7 +854,7 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 		if !found {
 			return false, nil
 		}
-		observedRestartTs, err := time.Parse(time.RFC3339, val)
+		observedRestartTS, err := time.Parse(time.RFC3339, val)
 		if err != nil {
 			return false, err
 		}
@@ -863,7 +863,7 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 			deployment.Status.UnavailableReplicas == 0 &&
 			deployment.GetGeneration() == deployment.Status.ObservedGeneration &&
 			// The last restart cannot be older than now.
-			(observedRestartTs.After(now) || observedRestartTs.Equal(now))
+			(observedRestartTS.After(now) || observedRestartTS.Equal(now))
 
 		return ready, nil
 	})

--- a/pkg/kubernetes/kubernetes_interface.go
+++ b/pkg/kubernetes/kubernetes_interface.go
@@ -77,15 +77,18 @@ type KubernetesConnector interface {
 	GetClusterServiceVersion(ctx context.Context, key types.NamespacedName) (*olmv1alpha1.ClusterServiceVersion, error)
 	// ListClusterServiceVersion list all CSVs for the given namespace.
 	ListClusterServiceVersion(ctx context.Context, namespace string) (*olmv1alpha1.ClusterServiceVersionList, error)
+	// UpdateClusterServiceVersion updates a ClusterServiceVersion and returns the updated object.
+	UpdateClusterServiceVersion(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion) (*olmv1alpha1.ClusterServiceVersion, error)
 	// DeleteClusterServiceVersion deletes a ClusterServiceVersion.
 	DeleteClusterServiceVersion(ctx context.Context, key types.NamespacedName) error
 	// DeleteObject deletes an object.
 	DeleteObject(obj runtime.Object) error
 	// ProvisionMonitoring provisions PMM monitoring.
 	ProvisionMonitoring(namespace string) error
+	// RestartOperator restarts the deployment of an operator managed by OLM.
+	RestartOperator(ctx context.Context, name, namespace string) error
+	// RestartDeployment restarts the given deployment.
 	RestartDeployment(ctx context.Context, name, namespace string) error
-	// RestartEverest restarts everest pod.
-	RestartEverest(ctx context.Context, name, namespace string) error
 	// ListEngineDeploymentNames returns a string array containing found engine deployments for the Everest.
 	ListEngineDeploymentNames(ctx context.Context, namespace string) ([]string, error)
 	// ApplyObject applies object.

--- a/pkg/kubernetes/kubernetes_interface.go
+++ b/pkg/kubernetes/kubernetes_interface.go
@@ -22,6 +22,7 @@ import (
 type KubernetesConnector interface {
 	// GetDeployment returns k8s deployment by provided name and namespace.
 	GetDeployment(ctx context.Context, name, namespace string) (*appsv1.Deployment, error)
+	// UpdateDeployment updates a deployment and returns the updated object.
 	UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error)
 	// WaitForInstallPlan waits until an install plan for the given operator and version is available.
 	WaitForInstallPlan(ctx context.Context, namespace, operatorName string, version *goversion.Version) (*olmv1alpha1.InstallPlan, error)

--- a/pkg/kubernetes/kubernetes_interface.go
+++ b/pkg/kubernetes/kubernetes_interface.go
@@ -22,6 +22,7 @@ import (
 type KubernetesConnector interface {
 	// GetDeployment returns k8s deployment by provided name and namespace.
 	GetDeployment(ctx context.Context, name, namespace string) (*appsv1.Deployment, error)
+	UpdateDeployment(ctx context.Context, deployment *appsv1.Deployment) (*appsv1.Deployment, error)
 	// WaitForInstallPlan waits until an install plan for the given operator and version is available.
 	WaitForInstallPlan(ctx context.Context, namespace, operatorName string, version *goversion.Version) (*olmv1alpha1.InstallPlan, error)
 	// ApproveInstallPlan approves an install plan.
@@ -82,6 +83,7 @@ type KubernetesConnector interface {
 	DeleteObject(obj runtime.Object) error
 	// ProvisionMonitoring provisions PMM monitoring.
 	ProvisionMonitoring(namespace string) error
+	RestartDeployment(ctx context.Context, name, namespace string) error
 	// RestartEverest restarts everest pod.
 	RestartEverest(ctx context.Context, name, namespace string) error
 	// ListEngineDeploymentNames returns a string array containing found engine deployments for the Everest.

--- a/pkg/kubernetes/mock_kubernetes_connector.go
+++ b/pkg/kubernetes/mock_kubernetes_connector.go
@@ -810,6 +810,24 @@ func (_m *MockKubernetesConnector) ProvisionMonitoring(namespace string) error {
 	return r0
 }
 
+// RestartDeployment provides a mock function with given fields: ctx, name, namespace
+func (_m *MockKubernetesConnector) RestartDeployment(ctx context.Context, name string, namespace string) error {
+	ret := _m.Called(ctx, name, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RestartDeployment")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, name, namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RestartEverest provides a mock function with given fields: ctx, name, namespace
 func (_m *MockKubernetesConnector) RestartEverest(ctx context.Context, name string, namespace string) error {
 	ret := _m.Called(ctx, name, namespace)
@@ -844,6 +862,36 @@ func (_m *MockKubernetesConnector) UpdateClusterRoleBinding(ctx context.Context,
 	}
 
 	return r0
+}
+
+// UpdateDeployment provides a mock function with given fields: ctx, deployment
+func (_m *MockKubernetesConnector) UpdateDeployment(ctx context.Context, deployment *v1.Deployment) (*v1.Deployment, error) {
+	ret := _m.Called(ctx, deployment)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateDeployment")
+	}
+
+	var r0 *v1.Deployment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1.Deployment) (*v1.Deployment, error)); ok {
+		return rf(ctx, deployment)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *v1.Deployment) *v1.Deployment); ok {
+		r0 = rf(ctx, deployment)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.Deployment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *v1.Deployment) error); ok {
+		r1 = rf(ctx, deployment)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UpgradeOperator provides a mock function with given fields: ctx, namespace, name

--- a/pkg/kubernetes/mock_kubernetes_connector.go
+++ b/pkg/kubernetes/mock_kubernetes_connector.go
@@ -828,12 +828,12 @@ func (_m *MockKubernetesConnector) RestartDeployment(ctx context.Context, name s
 	return r0
 }
 
-// RestartEverest provides a mock function with given fields: ctx, name, namespace
-func (_m *MockKubernetesConnector) RestartEverest(ctx context.Context, name string, namespace string) error {
+// RestartOperator provides a mock function with given fields: ctx, name, namespace
+func (_m *MockKubernetesConnector) RestartOperator(ctx context.Context, name string, namespace string) error {
 	ret := _m.Called(ctx, name, namespace)
 
 	if len(ret) == 0 {
-		panic("no return value specified for RestartEverest")
+		panic("no return value specified for RestartOperator")
 	}
 
 	var r0 error
@@ -862,6 +862,36 @@ func (_m *MockKubernetesConnector) UpdateClusterRoleBinding(ctx context.Context,
 	}
 
 	return r0
+}
+
+// UpdateClusterServiceVersion provides a mock function with given fields: ctx, csv
+func (_m *MockKubernetesConnector) UpdateClusterServiceVersion(ctx context.Context, csv *operatorsv1alpha1.ClusterServiceVersion) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	ret := _m.Called(ctx, csv)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateClusterServiceVersion")
+	}
+
+	var r0 *operatorsv1alpha1.ClusterServiceVersion
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *operatorsv1alpha1.ClusterServiceVersion) (*operatorsv1alpha1.ClusterServiceVersion, error)); ok {
+		return rf(ctx, csv)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *operatorsv1alpha1.ClusterServiceVersion) *operatorsv1alpha1.ClusterServiceVersion); ok {
+		r0 = rf(ctx, csv)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operatorsv1alpha1.ClusterServiceVersion)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *operatorsv1alpha1.ClusterServiceVersion) error); ok {
+		r1 = rf(ctx, csv)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UpdateDeployment provides a mock function with given fields: ctx, deployment


### PR DESCRIPTION
### Problem
Running `install` more than twice concurrently can lead to one of them failing at the Everest restart step.

### Causes
The current logic of the `RestartEverest` method lists all the pods for a Deployment and deletes them one after the other. Running install twice could lead to a NotFound error during delete as the previous run could have deleted the pods already, which means the latest install run is listing stale/deleted pods.

### Solution

Instead of having to list and re-create pods from code, handle restart by adding the `kubectl.kubernetes.io/restartedAt` annotation, which is how the `kubectl rollout restart` command works.

- For individual Deployments, add the annotation to the `.spec.template.metadata` section
- For OLM-managed Deployments, add the annotation to the parent CSV's `metadata.annotations` section

Once this annotation is set on the Deployment template, Kubernetes takes care of safely restarting the deployment and rolling out new pods.