### PR TITLE
EVEREST-1003 | [CLI] install: ignore `NotFound` errors during everest restart

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 	"github.com/percona/everest/data"
@@ -816,7 +817,7 @@ func (k *Kubernetes) RestartEverest(ctx context.Context, name, namespace string)
 	}
 	for _, pod := range podsToRestart {
 		err = k.client.DeletePod(ctx, namespace, pod.Name)
-		if err != nil {
+		if ctrlclient.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Problem

Running `install` concurrently can lead to one of them failing at the Everest restart step.

## Causes

The current logic of the `RestartEverest` method lists all the pods for a Deployment and deletes them one after the other. Running `install` twice could lead to a `NotFound` error during delete as the previous run could have deleted the pods, which means the latest install run is listed stale/deleted pods.