### PR TITLE
EVEREST-107 fix release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
           git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
 
           # Check if veneer has the new version listed
-          if ! grep -q "$VERSION" catalog/everest-operator/catalog.yaml; then
+          if ! grep -q "$VERSION$" catalog/everest-operator/catalog.yaml; then
             echo "catalog/everest-operator/catalog.yaml does not include the version $VERSION"
             echo "Update the file manually before running the workflow"
             exit 1


### PR DESCRIPTION
EVEREST-107

**Problem:**
During the release it turned out that the condition which interrupts the RC/Release for the manual catalog update step didn't work correctly: if there is a RC version `0.10.0-rcN` mentioned in catalog it considered `0.10.0` as to be already present, which is not correct. 

  



