### PR TITLE
EVEREST-979 | Reverse the behaviour of backup storage clean-up

### DIFF
--- a/api-tests/playwright.config.ts
+++ b/api-tests/playwright.config.ts
@@ -30,9 +30,8 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 5,
+  retries: 2,
+  workers: process.env.CI ? 5 : 5,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['github'],

--- a/api-tests/playwright.config.ts
+++ b/api-tests/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 5 : 5,
+  workers: process.env.CI ? 1 : 5,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['github'],

--- a/api-tests/playwright.config.ts
+++ b/api-tests/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: 2,
+  retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 5 : 5,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [

--- a/api-tests/tests/database-cluster-backups.spec.ts
+++ b/api-tests/tests/database-cluster-backups.spec.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 import { expect, test } from '@playwright/test'
 import * as th from './helpers'
-import {checkError, testsNs} from "./helpers";
+import {checkError, testsNs, checkObjectDeletion} from "./helpers";
 
 test('create/delete database cluster backups', async ({ request }) => {
   const bsName = th.suffixedName('storage')
@@ -164,7 +164,7 @@ test('list backups', async ({ request, page }) => {
   for (const payload of payloads) {
     await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${payload.metadata.name}`)
     response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-backups/${payload.metadata.name}`)
-    expect(response.status()).toBe(404)
+    checkObjectDeletion(response)
   }
 
   await th.deleteDBCluster(request, clusterName1)

--- a/api-tests/tests/database-cluster-backups.spec.ts
+++ b/api-tests/tests/database-cluster-backups.spec.ts
@@ -16,7 +16,7 @@ import { expect, test } from '@playwright/test'
 import * as th from './helpers'
 import {checkError, testsNs, checkObjectDeletion} from "./helpers";
 
-test('create/delete database cluster backups', async ({ request }) => {
+test('create/delete database cluster backups', async ({ request, page }) => {
   const bsName = th.suffixedName('storage')
   const clName = th.suffixedName('cluster')
 
@@ -49,7 +49,7 @@ test('create/delete database cluster backups', async ({ request }) => {
   expect(result.spec).toMatchObject(payload.spec)
 
   await th.deleteBackup(request, backupName)
-  await th.deleteDBCluster(request, clName)
+  await th.deleteDBCluster(request, page, clName)
   await th.deleteBackupStorage(request, bsName)
 })
 
@@ -167,7 +167,7 @@ test('list backups', async ({ request, page }) => {
     checkObjectDeletion(response)
   }
 
-  await th.deleteDBCluster(request, clusterName1)
-  await th.deleteDBCluster(request, clusterName2)
+  await th.deleteDBCluster(request, page, clusterName1)
+  await th.deleteDBCluster(request, page, clusterName2)
   await th.deleteBackupStorage(request, bsName)
 })

--- a/api-tests/tests/database-cluster-restores.spec.ts
+++ b/api-tests/tests/database-cluster-restores.spec.ts
@@ -78,10 +78,8 @@ test('create/update/delete database cluster restore', async ({ request, page }) 
   expect(response.status()).toBe(404)
 
   await th.deleteBackup(request, backupName)
-  await th.deleteDBCluster(request, clName)
-  await th.deleteDBCluster(request, clName2)
-  await th.waitClusterDeletion(request, page, clName)
-  await th.waitClusterDeletion(request, page, clName2)
+  await th.deleteDBCluster(request, page, clName)
+  await th.deleteDBCluster(request, page, clName2)
   await th.deleteBackupStorage(request, bsName)
 })
 
@@ -157,10 +155,8 @@ test('list restores', async ({ request, page }) => {
   }
 
   await th.deleteBackup(request, backupName)
-  await th.deleteDBCluster(request, clName1)
-  await th.deleteDBCluster(request, clName2)
-  await th.waitClusterDeletion(request, page, clName1)
-  await th.waitClusterDeletion(request, page, clName2)
+  await th.deleteDBCluster(request, page, clName1)
+  await th.deleteDBCluster(request, page, clName2)
   await th.deleteBackupStorage(request, bsName)
 })
 
@@ -212,7 +208,6 @@ test('create restore: validation errors', async ({ request, page }) => {
   expect(await response.text()).toContain('{"message":".spec cannot be empty"}')
 
   await th.deleteBackup(request, backupName)
-  await th.deleteDBCluster(request, clName)
-  await th.waitClusterDeletion(request, page, clName)
+  await th.deleteDBCluster(request, page, clName)
   await th.deleteBackupStorage(request, bsName)
 })

--- a/api-tests/tests/database-cluster-restores.spec.ts
+++ b/api-tests/tests/database-cluster-restores.spec.ts
@@ -17,7 +17,7 @@ import * as th from './helpers'
 import {checkError, testsNs} from "./helpers";
 
 
-test('create/update/delete database cluster restore', async ({ request }) => {
+test('create/update/delete database cluster restore', async ({ request, page }) => {
   const bsName = th.suffixedName('storage')
   const clName = th.suffixedName('cluster')
   const clName2 = th.suffixedName('cluster2')
@@ -78,9 +78,11 @@ test('create/update/delete database cluster restore', async ({ request }) => {
   expect(response.status()).toBe(404)
 
   await th.deleteBackup(request, backupName)
-  await th.deleteBackupStorage(request, bsName)
   await th.deleteDBCluster(request, clName)
   await th.deleteDBCluster(request, clName2)
+  await th.waitClusterDeletion(request, page, clName)
+  await th.waitClusterDeletion(request, page, clName2)
+  await th.deleteBackupStorage(request, bsName)
 })
 
 test('list restores', async ({ request, page }) => {
@@ -155,9 +157,11 @@ test('list restores', async ({ request, page }) => {
   }
 
   await th.deleteBackup(request, backupName)
-  await th.deleteBackupStorage(request, bsName)
   await th.deleteDBCluster(request, clName1)
   await th.deleteDBCluster(request, clName2)
+  await th.waitClusterDeletion(request, page, clName1)
+  await th.waitClusterDeletion(request, page, clName2)
+  await th.deleteBackupStorage(request, bsName)
 })
 
 test('create restore: validation errors', async ({ request, page }) => {
@@ -208,6 +212,7 @@ test('create restore: validation errors', async ({ request, page }) => {
   expect(await response.text()).toContain('{"message":".spec cannot be empty"}')
 
   await th.deleteBackup(request, backupName)
-  await th.deleteBackupStorage(request, bsName)
   await th.deleteDBCluster(request, clName)
+  await th.waitClusterDeletion(request, page, clName)
+  await th.deleteBackupStorage(request, bsName)
 })

--- a/api-tests/tests/database-cluster-restores.spec.ts
+++ b/api-tests/tests/database-cluster-restores.spec.ts
@@ -77,10 +77,10 @@ test('create/update/delete database cluster restore', async ({ request }) => {
   response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`)
   expect(response.status()).toBe(404)
 
-  await th.deleteDBCluster(request, clName)
-  await th.deleteDBCluster(request, clName2)
   await th.deleteBackup(request, backupName)
   await th.deleteBackupStorage(request, bsName)
+  await th.deleteDBCluster(request, clName)
+  await th.deleteDBCluster(request, clName2)
 })
 
 test('list restores', async ({ request, page }) => {
@@ -96,7 +96,6 @@ test('list restores', async ({ request, page }) => {
 
   const restoreName1 = th.suffixedName('restore1')
   const restoreName2 = th.suffixedName('restore2')
-  const restoreName3 = th.suffixedName('restore3')
 
   const payloads = [
     {
@@ -122,19 +121,6 @@ test('list restores', async ({ request, page }) => {
         dataSource: {
           dbClusterBackupName: backupName,
         },
-        dbClusterName: clName1,
-      },
-    },
-    {
-      apiVersion: 'everest.percona.com/v1alpha1',
-      kind: 'DatabaseClusterRestore',
-      metadata: {
-        name: restoreName3,
-      },
-      spec: {
-        dataSource: {
-          dbClusterBackupName: backupName,
-        },
         dbClusterName: clName2,
       },
     },
@@ -154,7 +140,7 @@ test('list restores', async ({ request, page }) => {
   let response = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clName1}/restores`)
   let result = await response.json()
 
-  expect(result.items).toHaveLength(2)
+  expect(result.items).toHaveLength(1)
 
   response = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clName2}/restores`)
   result = await response.json()
@@ -169,9 +155,9 @@ test('list restores', async ({ request, page }) => {
   }
 
   await th.deleteBackup(request, backupName)
+  await th.deleteBackupStorage(request, bsName)
   await th.deleteDBCluster(request, clName1)
   await th.deleteDBCluster(request, clName2)
-  await th.deleteBackupStorage(request, bsName)
 })
 
 test('create restore: validation errors', async ({ request, page }) => {

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -19,7 +19,8 @@ import {
   testPrefix,
   waitClusterDeletion,
   createMonitoringConfig,
-  suffixedName, deleteMonitoringConfig
+  suffixedName, deleteMonitoringConfig,
+  deleteDBCluster,
 } from "@tests/tests/helpers";
 
 test.setTimeout(360 * 1000)
@@ -77,7 +78,7 @@ test('create db cluster with monitoring config', async ({ request, page }) => {
       timeout: 60 * 1000,
     })
   } finally {
-    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
+    await deleteDBCluster(request, clusterName)
     await waitClusterDeletion(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName1)
   }
@@ -152,7 +153,7 @@ test('update db cluster with a new monitoring config', async ({ request, page })
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBe(monitoringConfigName2)
   } finally {
-    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
+    await deleteDBCluster(request, clusterName)
     await waitClusterDeletion(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName1)
     await deleteMonitoringConfig(request, monitoringConfigName2)
@@ -223,7 +224,7 @@ test('update db cluster without monitoring config with a new monitoring config',
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBe(monitoringConfigName2)
   } finally {
-    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
+    await deleteDBCluster(request, clusterName)
     await waitClusterDeletion(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName2)
   }
@@ -294,7 +295,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBeFalsy()
   } finally {
-    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
+    await deleteDBCluster(request, clusterName)
     await waitClusterDeletion(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName1)
   }

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -77,8 +77,7 @@ test('create db cluster with monitoring config', async ({ request, page }) => {
       timeout: 60 * 1000,
     })
   } finally {
-    await deleteDBCluster(request, clusterName)
-    await waitClusterDeletion(request, page, clusterName)
+    await deleteDBCluster(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName1)
   }
 })
@@ -158,8 +157,7 @@ test('update db cluster with a new monitoring config', async ({ request, page })
     })
 
   } finally {
-    await deleteDBCluster(request, clusterName)
-    await waitClusterDeletion(request, page, clusterName)
+    await deleteDBCluster(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName1)
     await deleteMonitoringConfig(request, monitoringConfigName2)
   }
@@ -235,7 +233,7 @@ test('update db cluster without monitoring config with a new monitoring config',
     })
 
   } finally {
-    await deleteDBCluster(request, clusterName)
+    await deleteDBCluster(request, page, clusterName)
     await waitClusterDeletion(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName2)
   }
@@ -312,7 +310,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
     })
 
   } finally {
-    await deleteDBCluster(request, clusterName)
+    await deleteDBCluster(request, page, clusterName)
     await waitClusterDeletion(request, page, clusterName)
     await deleteMonitoringConfig(request, monitoringConfigName1)
   }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -53,8 +53,16 @@ export const createDBCluster = async (request, name) => {
 }
 
 export const deleteDBCluster = async (request, name) => {
-  const res = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
+  let res = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
 
+  const cluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
+  if (cluster.status() == 404) {
+    return;
+  }
+  let data = await cluster.json()
+  data.metadata.finalizers = null
+
+  res = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${name}`, { data })
   await checkError(res)
 }
 

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -52,18 +52,20 @@ export const createDBCluster = async (request, name) => {
   await checkError(postReq)
 }
 
-export const deleteDBCluster = async (request, name) => {
+export const deleteDBCluster = async (request, page, name) => {
   let res = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
 
-  const cluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
-  if (cluster.status() == 404) {
-    return;
-  }
-  let data = await cluster.json()
-  data.metadata.finalizers = null
+  for (let i = 0; i < 100; i++) {
+    const cluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
+    if (cluster.status() == 404) {
+      return;
+    }
+    let data = await cluster.json()
+    data.metadata.finalizers = null
 
-  res = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${name}`, { data })
-  await checkError(res)
+    await request.put(`/v1/namespaces/${testsNs}/database-clusters/${name}`, { data })
+    await page.waitForTimeout(1000)
+  }
 }
 
 export const createBackupStorage = async (request, name) => {

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -111,7 +111,7 @@ export const createBackup = async (request,  clusterName, backupName, storageNam
 }
 
 export const deleteBackup = async (request, backupName) => {
-  const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}`)
+  const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}?cleanupBackupStorage=true`)
 
   await checkError(res)
 }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -111,7 +111,7 @@ export const createBackup = async (request,  clusterName, backupName, storageNam
 }
 
 export const deleteBackup = async (request, backupName) => {
-  const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}?cleanupBackupStorage=true`)
+  const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}`)
 
   await checkError(res)
 }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -122,6 +122,14 @@ export const deleteRestore = async (request, restoreName) => {
   await checkError(res)
 }
 
+export const checkObjectDeletion = async (obj) => {
+  if (obj.status() == 200) {
+    expect((await obj.json()).metadata["deletionTimestamp"]).not.toBe('');
+  } else {
+    expect(obj.status()).toBe(404)
+  }
+}
+
 export const checkClusterDeletion = async (cluster) => {
   if (cluster.status() == 200) {
     expect((await cluster.json()).metadata["deletionTimestamp"]).not.toBe('');

--- a/api-tests/tests/pg-clusters.spec.ts
+++ b/api-tests/tests/pg-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {checkClusterDeletion, checkError, testsNs} from "@tests/tests/helpers";
+import {checkError, deleteDBCluster, testsNs} from "@tests/tests/helpers";
 
 let recommendedVersion
 
@@ -107,12 +107,7 @@ test('create/edit/delete single node pg cluster', async ({ request, page }) => {
 
   expect((await updatedPGCluster.json()).spec.clusterSize).toBe(pgPayload.spec.clusterSize)
 
-  let deleteResult = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkError(deleteResult)
-
-  pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(pgCluster)
-
+  await deleteDBCluster(request, page, clusterName)
 })
 
 test('expose pg cluster after creation', async ({ request, page }) => {
@@ -188,11 +183,7 @@ test('expose pg cluster after creation', async ({ request, page }) => {
 
   expect((await updatedPGCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  let deleteResponse = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkError(deleteResponse)
-
-  pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(pgCluster)
+  await deleteDBCluster(request, page, clusterName)
 })
 
 test('expose pg cluster on EKS to the public internet and scale up', async ({ request, page }) => {
@@ -262,9 +253,5 @@ test('expose pg cluster on EKS to the public internet and scale up', async ({ re
 
   await checkError(updatedPGCluster)
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await page.waitForTimeout(1000)
-
-  const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(pgCluster)
+  await deleteDBCluster(request, page, clusterName)
 })

--- a/api-tests/tests/psmdb-clusters.spec.ts
+++ b/api-tests/tests/psmdb-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {checkClusterDeletion, checkError, testsNs} from "@tests/tests/helpers";
+import {checkError, deleteDBCluster, testsNs} from "@tests/tests/helpers";
 
 
 test.beforeAll(async ({ request }) => {
@@ -98,11 +98,7 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
 
   expect((await updatedPSMDBCluster.json()).spec.engine.config).toBe(psmdbPayload.spec.engine.config)
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-
-  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(psmdbCluster)
-
+  await deleteDBCluster(request, page, clusterName)
 })
 
 test('expose psmdb cluster after creation', async ({ request, page }) => {
@@ -184,10 +180,7 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
 
   expect((await updatedPSMDBCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-
-  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(psmdbCluster)
+  await deleteDBCluster(request, page, clusterName)
 })
 
 test('expose psmdb cluster on EKS to the public internet and scale up', async ({ request, page }) => {
@@ -264,9 +257,5 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
 
   await checkError(psmdbCluster)
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await page.waitForTimeout(1000)
-
-  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(psmdbCluster)
+  await deleteDBCluster(request, page, clusterName)
 })

--- a/api-tests/tests/pxc-clusters.spec.ts
+++ b/api-tests/tests/pxc-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {checkClusterDeletion, checkError, testsNs} from "@tests/tests/helpers";
+import {checkClusterDeletion, checkError, testsNs, deleteDBCluster, waitClusterDeletion} from "@tests/tests/helpers";
 
 let recommendedVersion
 
@@ -119,10 +119,8 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
 
   expect((await updatedPXCCluster.json()).spec.databaseConfig).toBe(pxcPayload.spec.databaseConfig)
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-
-  pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(pxcCluster)
+  await deleteDBCluster(request, clusterName)
+  await waitClusterDeletion(request, page, clusterName)
 })
 
 test('expose pxc cluster after creation', async ({ request, page }) => {
@@ -198,10 +196,8 @@ test('expose pxc cluster after creation', async ({ request, page }) => {
 
   expect((await updatedPXCCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-
-  pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await checkClusterDeletion(pxcCluster)
+  await deleteDBCluster(request, clusterName)
+  await waitClusterDeletion(request, page, clusterName)
 })
 
 test('expose pxc cluster on EKS to the public internet and scale up', async ({ request, page }) => {
@@ -272,10 +268,6 @@ test('expose pxc cluster on EKS to the public internet and scale up', async ({ r
 
   await checkError(updatedPXCCluster)
 
-  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-  await page.waitForTimeout(1000)
-
-  const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
-
-  await checkClusterDeletion(pxcCluster)
+  await deleteDBCluster(request, clusterName)
+  await waitClusterDeletion(request, page, clusterName)
 })

--- a/api-tests/tests/pxc-clusters.spec.ts
+++ b/api-tests/tests/pxc-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {checkClusterDeletion, checkError, testsNs, deleteDBCluster, waitClusterDeletion} from "@tests/tests/helpers";
+import {checkError, testsNs, deleteDBCluster} from "@tests/tests/helpers";
 
 let recommendedVersion
 
@@ -119,8 +119,7 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
 
   expect((await updatedPXCCluster.json()).spec.databaseConfig).toBe(pxcPayload.spec.databaseConfig)
 
-  await deleteDBCluster(request, clusterName)
-  await waitClusterDeletion(request, page, clusterName)
+  await deleteDBCluster(request, page, clusterName)
 })
 
 test('expose pxc cluster after creation', async ({ request, page }) => {
@@ -196,8 +195,7 @@ test('expose pxc cluster after creation', async ({ request, page }) => {
 
   expect((await updatedPXCCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  await deleteDBCluster(request, clusterName)
-  await waitClusterDeletion(request, page, clusterName)
+  await deleteDBCluster(request, page, clusterName)
 })
 
 test('expose pxc cluster on EKS to the public internet and scale up', async ({ request, page }) => {
@@ -268,6 +266,5 @@ test('expose pxc cluster on EKS to the public internet and scale up', async ({ r
 
   await checkError(updatedPXCCluster)
 
-  await deleteDBCluster(request, clusterName)
-  await waitClusterDeletion(request, page, clusterName)
+  await deleteDBCluster(request, page, clusterName)
 })

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -75,7 +75,7 @@ func (e *EverestServer) DeleteDatabaseCluster(
 			if backup.Spec.DBClusterName != name {
 				continue
 			}
-			if err := e.ensureBackupStorageProtection(reqCtx, &backup); err != nil {
+			if err := e.ensureBackupStorageProtection(reqCtx, &backup); err != nil { //nolint:gosec
 				return errors.Join(err, errors.New("could not ensure backup storage protection"))
 			}
 		}
@@ -88,7 +88,7 @@ func (e *EverestServer) DeleteDatabaseCluster(
 		if backup.Spec.DBClusterName != name {
 			continue
 		}
-		if err := e.ensureBackupForegroundDeletion(reqCtx, &backup); err != nil {
+		if err := e.ensureBackupForegroundDeletion(reqCtx, &backup); err != nil { //nolint:gosec
 			return errors.Join(err, errors.New("could not ensure foreground deletion"))
 		}
 	}

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -72,7 +72,7 @@ func (e *EverestServer) DeleteDatabaseCluster(
 	if !cleanupStorage {
 		for _, backup := range backups.Items {
 			// Doesn't belong to this cluster, skip.
-			if backup.Spec.DBClusterName != name {
+			if backup.Spec.DBClusterName != name || !backup.GetDeletionTimestamp().IsZero() {
 				continue
 			}
 			if err := e.ensureBackupStorageProtection(reqCtx, &backup); err != nil { //nolint:gosec
@@ -85,7 +85,7 @@ func (e *EverestServer) DeleteDatabaseCluster(
 	// so that they're visible on the UI while getting deleted.
 	for _, backup := range backups.Items {
 		// Doesn't belong to this cluster, skip.
-		if backup.Spec.DBClusterName != name {
+		if backup.Spec.DBClusterName != name || !backup.GetDeletionTimestamp().IsZero() {
 			continue
 		}
 		if err := e.ensureBackupForegroundDeletion(reqCtx, &backup); err != nil { //nolint:gosec

--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -36,7 +36,6 @@ import (
 const (
 	databaseClusterBackupKind = "databaseclusterbackups"
 
-	storageProtectionFinalizer  = "everest.percona.com/dbb-storage-protection"
 	foregroundDeletionFinalizer = "foregroundDeletion"
 )
 
@@ -117,7 +116,7 @@ func (e *EverestServer) ensureBackupStorageProtection(ctx context.Context, backu
 		if err != nil {
 			return err
 		}
-		controllerutil.AddFinalizer(backup, storageProtectionFinalizer)
+		controllerutil.AddFinalizer(backup, everestv1alpha1.DBBackupStorageProtectionFinalizer)
 		controllerutil.AddFinalizer(backup, foregroundDeletionFinalizer)
 		_, err = e.kubeClient.UpdateDatabaseClusterBackup(ctx, backup)
 		return err

--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -40,6 +40,7 @@ const (
 	foregroundDeletionFinalizer = "foregroundDeletion"
 )
 
+//nolint:gochecknoglobals
 var everestAPIConstantBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5)
 
 // ListDatabaseClusterBackups returns list of the created database cluster backups on the specified kubernetes cluster.

--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -41,7 +41,7 @@ const (
 )
 
 //nolint:gochecknoglobals
-var everestAPIConstantBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5)
+var everestAPIConstantBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 10)
 
 // ListDatabaseClusterBackups returns list of the created database cluster backups on the specified kubernetes cluster.
 func (e *EverestServer) ListDatabaseClusterBackups(ctx echo.Context, namespace, name string) error {

--- a/api/database_engine.go
+++ b/api/database_engine.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net/http"
 	"slices"
-	"time"
 
 	"github.com/AlekSi/pointer"
 	"github.com/cenkalti/backoff/v4"
@@ -130,14 +129,10 @@ func (e *EverestServer) UpgradeDatabaseEngineOperator(ctx echo.Context, namespac
 // startOperatorUpgradeWithRetry wraps the startOperatorUpgrade function with a retry mechanism.
 // This is done to reduce the chances of failures due to resource conflicts.
 func (e *EverestServer) startOperatorUpgradeWithRetry(ctx context.Context, targetVersion, namespace, name string) error {
-	var b backoff.BackOff
-	b = backoff.NewConstantBackOff(3 * time.Second)
-	b = backoff.WithMaxRetries(b, 5)
-	b = backoff.WithContext(b, ctx)
 	return backoff.Retry(func() error {
 		return e.startOperatorUpgrade(ctx, targetVersion, namespace, name)
 	},
-		b,
+		backoff.WithContext(everestAPIConstantBackoff, ctx),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.23.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240426070203-91f4233b9320
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240514121858-9c270ed11e06
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240426070203-91f4233b9320 h1:xvYCCmA450nEm0o5eYAgkYaRwN0hat8XGkgtUCHzXwI=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240426070203-91f4233b9320/go.mod h1:TOvVDtoaChBQBZRMRQwcWs89fA6UuR9huFxxV11Ww3I=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240514121858-9c270ed11e06 h1:oVCfexKFqKnRyDRWVyAEfMj6s6adUpF7Zgq28KSBcfs=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240514121858-9c270ed11e06/go.mod h1:TOvVDtoaChBQBZRMRQwcWs89fA6UuR9huFxxV11Ww3I=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=


### PR DESCRIPTION
## Description

Earlier, the everest-operator always preserved backup storage by default. Now the behaviour has reversed, meaning that the operator will now delete the storage always by default. In order to preserve the storage, we must set a specific finalizer on the backups.

This change in behaviour has been introduced in order to allow storage clean-up for backups that are deleted due to retention settings.