### PR TITLE
CI should use manifests from the PR branch during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build:                ## Build binaries
 	go build -v $(LD_FLAGS_API) -o bin/everest ./cmd
 
 build-cli:                ## Build binaries
-	go build -v $(LD_FLAGS_CLI_TEST) -o bin/everestctl ./cmd/cli
+	go build -tags debug -v $(LD_FLAGS_CLI_TEST) -o bin/everestctl ./cmd/cli
 
 release: FLAGS += -X 'github.com/percona/everest/cmd/config.TelemetryURL=https://check.percona.com' -X 'github.com/percona/everest/cmd/config.TelemetryInterval=24h'
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
+	"github.com/percona/everest/cmd/config"
 )
 
 const (
@@ -30,6 +31,7 @@ const (
 	releaseCatalogImage = "docker.io/percona/everest-catalog:%s"
 	devManifestURL      = "https://raw.githubusercontent.com/percona/everest/main/deploy/quickstart-k8s.yaml"
 	releaseManifestURL  = "https://raw.githubusercontent.com/percona/everest/v%s/deploy/quickstart-k8s.yaml"
+	debugManifestURL    = "https://raw.githubusercontent.com/percona/everest/%s/deploy/quickstart-k8s.yaml"
 
 	everestOperatorChannelStable = "stable-v0"
 	everestOperatorChannelFast   = "fast-v0"
@@ -65,6 +67,9 @@ func CatalogImage(v *goversion.Version) string {
 
 // ManifestURL returns a manifest URL to install Everest.
 func ManifestURL(v *goversion.Version) string {
+	if config.Debug {
+		return fmt.Sprintf(debugManifestURL, FullCommit)
+	}
 	if isDevVersion(Version) {
 		return devManifestURL
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
+
 	"github.com/percona/everest/cmd/config"
 )
 


### PR DESCRIPTION
### Problem

Currently the CI uses the `quickstart-k8s.yaml` file from the main branch when installing Everest. This makes it difficult to test changes with the file. 

### Solution

The CI build of the CLI should pick up the manifest from the latest commit of the branch.