### PR TITLE
EVEREST-1063 Schedules validation

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -762,7 +762,7 @@ type apiSchedule []struct {
 func checkDuplicateSchedules(schedules apiSchedule) error {
 	m := make(map[string]struct{})
 	for _, s := range schedules {
-		key := s.Schedule + s.BackupStorageName
+		key := s.Schedule
 		if _, ok := m[key]; ok {
 			return errDuplicatedSchedules
 		}

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -422,7 +422,7 @@ func TestValidateBackupSpec(t *testing.T) {
 		},
 		{
 			name:    "errDuplicatedSchedules",
-			cluster: []byte(`{"spec": {"backup": {"enabled": true, "schedules": [{"schedule": "0 0 * * *", "name": "name"}, {"schedule": "0 0 * * *", "name": "name"}]}}}`),
+			cluster: []byte(`{"spec": {"backup": {"enabled": true, "schedules": [{"schedule": "0 0 * * *", "name": "name"}, {"schedule": "0 0 * * *", "name": "otherName"}]}}}`),
 			err:     errDuplicatedSchedules,
 		},
 		{


### PR DESCRIPTION
EVEREST-1063

Recently there was introduced validation that forbid the duplicated schedules. The schedules with the same storage and time were considered duplicated.
Since the purpose of the validation is to reduce the db load and potential problems which the user may face in case of several backups running simultaneously, it was decided to change the validation so that the API wouldn't allow the same time regardless of the storage.  