### PR TITLE
EVEREST-1097 | Add input validation for oidc configure command

### DIFF
--- a/pkg/oidc/configure.go
+++ b/pkg/oidc/configure.go
@@ -85,6 +85,12 @@ func (u *OIDC) Run(ctx context.Context) error {
 		return errors.New("clientID and/or issuerURL are not provided")
 	}
 
+	// Check if we can connect to the provider.
+	_, err := getProviderConfig(ctx, issuerURL)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to connect with OIDC provider"))
+	}
+
 	oidcCfg := common.OIDCConfig{
 		IssuerURL: issuerURL,
 		ClientID:  clientID,

--- a/pkg/oidc/configure.go
+++ b/pkg/oidc/configure.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/AlecAivazis/survey/v2"
 	"go.uber.org/zap"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 )
@@ -67,14 +67,16 @@ func (u *OIDC) Run(ctx context.Context) error {
 	if issuerURL == "" {
 		if err := survey.AskOne(&survey.Input{
 			Message: "Enter issuer URL",
-		}, &issuerURL); err != nil {
+		}, &issuerURL,
+		); err != nil {
 			return err
 		}
 	}
 	if clientID == "" {
 		if err := survey.AskOne(&survey.Input{
 			Message: "Enter client ID",
-		}, &clientID); err != nil {
+		}, &clientID,
+		); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- Provide prompt if empty config provided
- Throw error is empty config provided to prompt
- Try connecting with OIDC provider before storing in ConfigMap