### PR TITLE
[UI] EVEREST-872 EVEREST-873 Fix logic for delete modal

### DIFF
--- a/ui/apps/everest/src/components/custom-confirm-dialog/custom-checkbox/custom-checkbox.tsx
+++ b/ui/apps/everest/src/components/custom-confirm-dialog/custom-checkbox/custom-checkbox.tsx
@@ -5,11 +5,12 @@ import { CustomCheckboxProps } from './custom-checkbox.types';
 export const CustomCheckbox = ({
   formControlLabelProps,
   checkboxMessage,
+  disabled = false,
 }: CustomCheckboxProps) => (
   <FormControlLabel
     {...formControlLabelProps}
     label={checkboxMessage}
-    control={<CheckboxInput name="dataCheckbox" />}
+    control={<CheckboxInput disabled={disabled} name="dataCheckbox" />}
   />
 );
 

--- a/ui/apps/everest/src/components/custom-confirm-dialog/custom-checkbox/custom-checkbox.types.ts
+++ b/ui/apps/everest/src/components/custom-confirm-dialog/custom-checkbox/custom-checkbox.types.ts
@@ -1,6 +1,8 @@
 import { FormControlLabelProps } from '@mui/material';
+import { ReactNode } from 'react';
 
 export type CustomCheckboxProps = {
   formControlLabelProps?: Omit<FormControlLabelProps, 'label' | 'control'>;
-  checkboxMessage: string;
+  checkboxMessage: ReactNode;
+  disabled?: boolean;
 };

--- a/ui/apps/everest/src/components/custom-confirm-dialog/custom-confirm-dialog-consts.ts
+++ b/ui/apps/everest/src/components/custom-confirm-dialog/custom-confirm-dialog-consts.ts
@@ -1,6 +1,6 @@
 import { CustomConfirmDialogFields } from './custom-confirm-dialog.types';
 
-export const customConfirmDialogDefaultValues = {
+export const customConfirmDialogDefaultValues = (disableCheckbox: boolean) => ({
   [CustomConfirmDialogFields.confirmInput]: '',
-  [CustomConfirmDialogFields.dataCheckbox]: false,
-};
+  [CustomConfirmDialogFields.dataCheckbox]: disableCheckbox ? true : false,
+});

--- a/ui/apps/everest/src/components/custom-confirm-dialog/custom-confirm-dialog.tsx
+++ b/ui/apps/everest/src/components/custom-confirm-dialog/custom-confirm-dialog.tsx
@@ -20,7 +20,7 @@ import { TextInput } from '@percona/ui-lib';
 import { kebabize } from '@percona/utils';
 import { customConfirmDialogDefaultValues } from './custom-confirm-dialog-consts';
 import { IrreversibleAction } from '../irreversible-action';
-import { DialogContent } from '@mui/material';
+import { Box, DialogContent, Tooltip } from '@mui/material';
 import { ReactNode } from 'react';
 import { CustomCheckbox } from 'components/custom-confirm-dialog/custom-checkbox/custom-checkbox';
 import {
@@ -28,6 +28,7 @@ import {
   CustomConfirmDialogType,
   customConfirmDialogSchema,
 } from './custom-confirm-dialog.types';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 interface CustomConfirmDialogProps<T extends CustomConfirmDialogType>
   extends Omit<
@@ -44,7 +45,10 @@ interface CustomConfirmDialogProps<T extends CustomConfirmDialogType>
   confirmationInput?: boolean;
   alertTitle?: string;
   alertMessage: string;
-  checkboxMessage: string;
+  checkboxMessage?: string;
+  disableCheckbox?: boolean;
+  hideCheckbox?: boolean;
+  tooltipText?: string;
 }
 export const CustomConfirmDialog = ({
   inputLabel,
@@ -59,6 +63,9 @@ export const CustomConfirmDialog = ({
   alertTitle = 'Irreversible action',
   alertMessage,
   checkboxMessage,
+  disableCheckbox = false,
+  hideCheckbox = false,
+  tooltipText = '',
   ...props
 }: CustomConfirmDialogProps<CustomConfirmDialogType>) => {
   const onSubmit: SubmitHandler<CustomConfirmDialogType> = (data) => {
@@ -69,7 +76,7 @@ export const CustomConfirmDialog = ({
     <FormDialog
       onSubmit={onSubmit}
       schema={customConfirmDialogSchema(selectedId, confirmationInput)}
-      defaultValues={customConfirmDialogDefaultValues}
+      defaultValues={customConfirmDialogDefaultValues(disableCheckbox)}
       dataTestId={selectedId && kebabize(selectedId)}
       submitMessage={submitMessage}
       cancelMessage={cancelMessage}
@@ -88,10 +95,29 @@ export const CustomConfirmDialog = ({
           }}
         />
       )}
-      <CustomCheckbox
-        checkboxMessage={checkboxMessage}
-        formControlLabelProps={{ sx: { mt: 2, pl: 1 } }}
-      />
+      {checkboxMessage && !hideCheckbox && (
+        <CustomCheckbox
+          checkboxMessage={
+            disableCheckbox ? (
+              <Box display="flex" mt={0}>
+                {checkboxMessage}
+                <Tooltip
+                  title={tooltipText}
+                  arrow
+                  placement="right"
+                  sx={{ ml: 1 }}
+                >
+                  <InfoOutlinedIcon />
+                </Tooltip>
+              </Box>
+            ) : (
+              <>{checkboxMessage}</>
+            )
+          }
+          formControlLabelProps={{ sx: { mt: 2, pl: 1 } }}
+          disabled={disableCheckbox}
+        />
+      )}
     </FormDialog>
   );
 };

--- a/ui/apps/everest/src/hooks/api/db-cluster/useDbActions.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/useDbActions.ts
@@ -108,14 +108,14 @@ export const useDbActions = () => {
   };
 
   const handleConfirmDelete = (
-    cleanupBackupStorage: boolean,
+    keepBackupStorageData: boolean,
     redirect?: string
   ) => {
     deleteDbCluster(
       {
         dbClusterName: selectedDbCluster!.metadata.name,
         namespace: selectedDbCluster!.metadata.namespace,
-        cleanupBackupStorage: cleanupBackupStorage,
+        cleanupBackupStorage: !keepBackupStorageData,
       },
       {
         onSuccess: (_, variables) => {

--- a/ui/apps/everest/src/pages/databases/dbClusterView.messages.tsx
+++ b/ui/apps/everest/src/pages/databases/dbClusterView.messages.tsx
@@ -74,7 +74,9 @@ export const Messages = {
     databaseName: 'Database name',
     alertMessage:
       'This action will permanently destroy your database and you will not be able to recover it.',
-    checkboxMessage: 'Delete backups storage data',
+    checkboxMessage: 'Keep backups storage data',
+    disabledCheckboxForPGTooltip:
+      'Backups storage data is kept for PostgreSQL databases.',
     confirmButtom: 'Delete',
   },
   responseMessages: {

--- a/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.messages.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.messages.tsx
@@ -1,8 +1,23 @@
+import { DbEngineType } from '@percona/types';
+
 export const Messages = {
   deleteDialog: {
     header: 'Delete backup',
-    content: (backupName: string) =>
-      `Are you sure you want to permanently delete "${backupName}" and any datasets it contains?`,
+    content: (backupName: string, dbType: DbEngineType) => (
+      <>
+        {dbType === DbEngineType.POSTGRESQL ? (
+          <>
+            Are you sure you want to permanently delete <b>{backupName}</b>{' '}
+            backup? The backup data will not be deleted from the backup storage.
+          </>
+        ) : (
+          <>
+            Are you sure you want to permanently delete <b>{backupName}</b>{' '}
+            backup?
+          </>
+        )}
+      </>
+    ),
     alertMessage:
       'This action will permanently destroy your backup and you will not be able to recover it.',
     confirmButton: 'Delete',

--- a/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.tsx
@@ -37,6 +37,7 @@ import { BACKUP_STATUS_TO_BASE_STATUS } from './backups-list.constants';
 import { Messages } from './backups-list.messages';
 import BackupListTableHeader from './table-header';
 import { CustomConfirmDialog } from 'components/custom-confirm-dialog/custom-confirm-dialog.tsx';
+import { DbEngineType } from '@percona/types';
 
 export const BackupsList = () => {
   const queryClient = useQueryClient();
@@ -230,15 +231,22 @@ export const BackupsList = () => {
           selectedId={selectedBackup}
           closeModal={handleCloseDeleteDialog}
           headerMessage={Messages.deleteDialog.header}
-          handleConfirm={({ dataCheckbox: cleanupBackupStorage }) =>
-            handleConfirmDelete(selectedBackup, cleanupBackupStorage)
+          handleConfirm={() =>
+            handleConfirmDelete(
+              selectedBackup,
+              dbCluster.spec.engine.type === DbEngineType.POSTGRESQL
+                ? false
+                : true
+            )
           }
           submitting={deletingBackup}
           confirmationInput={false}
-          dialogContent={Messages.deleteDialog.content(selectedBackup)}
+          dialogContent={Messages.deleteDialog.content(
+            selectedBackup,
+            dbCluster.spec.engine.type
+          )}
           alertMessage={Messages.deleteDialog.alertMessage}
           submitMessage={Messages.deleteDialog.confirmButton}
-          checkboxMessage={Messages.deleteDialog.checkboxMessage}
         />
       )}
       {openRestoreDbModal && dbCluster && (

--- a/ui/apps/everest/src/pages/db-cluster-details/db-action-button.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/db-action-button.tsx
@@ -17,6 +17,8 @@ import { Link, useParams } from 'react-router-dom';
 import { Messages as ClusterDetailsMessages } from './db-cluster-details.messages';
 import { DbCluster, DbClusterStatus } from 'shared-types/dbCluster.types';
 import { CustomConfirmDialog } from 'components/custom-confirm-dialog';
+import { useDbBackups } from 'hooks/api/backups/useBackups';
+import { DbEngineType } from '@percona/types';
 
 export const DbActionButton = ({ dbCluster }: { dbCluster: DbCluster }) => {
   const { dbClusterName, namespace = '' } = useParams();
@@ -42,9 +44,17 @@ export const DbActionButton = ({ dbCluster }: { dbCluster: DbCluster }) => {
     setAnchorEl(null);
   };
 
-  const handleDelete = (cleanupBackupStorage: boolean) => {
-    handleConfirmDelete(cleanupBackupStorage, '/databases');
+  const handleDelete = (keepBackupStorageData: boolean) => {
+    handleConfirmDelete(keepBackupStorageData, '/databases');
   };
+
+  const { data: backups = [] } = useDbBackups(dbClusterName!, namespace!, {
+    enabled: !!dbClusterName,
+    refetchInterval: 10 * 1000,
+  });
+  const disableKeepDataCheckbox =
+    dbCluster?.spec.engine.type === DbEngineType.POSTGRESQL;
+  const hideCheckbox = !backups.length;
 
   return (
     <Box>
@@ -196,13 +206,16 @@ export const DbActionButton = ({ dbCluster }: { dbCluster: DbCluster }) => {
           headerMessage={Messages.deleteModal.header}
           submitting={deletingCluster}
           selectedId={dbCluster.metadata.name || ''}
-          handleConfirm={({ dataCheckbox: cleanupBackupStorage }) =>
-            handleDelete(cleanupBackupStorage)
+          handleConfirm={({ dataCheckbox: keepBackupStorageData }) =>
+            handleDelete(keepBackupStorageData)
           }
           alertMessage={Messages.deleteModal.alertMessage}
           dialogContent={Messages.deleteModal.content(dbCluster.metadata.name)}
           submitMessage={Messages.deleteModal.confirmButtom}
           checkboxMessage={Messages.deleteModal.checkboxMessage}
+          disableCheckbox={disableKeepDataCheckbox}
+          tooltipText={Messages.deleteModal.disabledCheckboxForPGTooltip}
+          hideCheckbox={hideCheckbox}
         />
       )}
     </Box>

--- a/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.tsx
+++ b/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.tsx
@@ -11,6 +11,7 @@ const Checkbox = ({
   control,
   controllerProps,
   checkboxProps,
+  disabled,
 }: CheckboxProps) => {
   const { control: contextControl } = useFormContext();
 
@@ -22,6 +23,7 @@ const Checkbox = ({
         <MUICheckbox
           {...field}
           checked={field.value}
+          disabled={disabled}
           {...checkboxProps}
           inputProps={{
             // @ts-expect-error

--- a/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.types.ts
+++ b/ui/packages/ui-lib/src/form/inputs/checkbox/checkbox.types.ts
@@ -9,4 +9,5 @@ export type CheckboxProps = {
   controllerProps?: Omit<UseControllerProps, 'name'>;
   checkboxProps?: MUICheckboxProps;
   labelProps?: LabeledContentProps;
+  disabled?: boolean;
 };


### PR DESCRIPTION
Changes included following tickets:
> [EVEREST-873 - Give users the option to delete the data from backup storage when deleting a DB](https://perconadev.atlassian.net/browse/EVEREST-873)
> [EVEREST-872- Give users the option to delete the data from backup storage when deleting a backup](https://perconadev.atlassian.net/browse/EVEREST-872)

[New FIGMA design](https://www.figma.com/design/WasdpYdmJNoTn4zgFdHJcF/Everest-lib?node-id=244-39196&t=tPvWHoy3p7dVBhbr-0)


Delete Postgresql DB

- w/o backups

https://github.com/percona/everest/assets/79999411/f3151bf6-c95b-49ec-a86e-db58274d0ea5


- with backups

https://github.com/percona/everest/assets/79999411/e3cf556c-3e6d-47f3-8a40-22ca97319c95

Delete other type of DB

- with backups


https://github.com/percona/everest/assets/79999411/5e3e17a8-2245-465b-84ab-edeb994cf4d6

- w/o backups

https://github.com/percona/everest/assets/79999411/11e9ad58-784f-4a34-856b-0125422a6eac

Delete backup

- for Postgresql DB


https://github.com/percona/everest/assets/79999411/e09e1ba2-2919-4603-93c5-055eb9132597



- for other type of DB 


https://github.com/percona/everest/assets/79999411/c5842a5d-7f88-4e99-9849-496ddf6c28fd




