### PR TITLE
EVEREST-1095 Unprotect settings API

### DIFF
--- a/api/everest.go
+++ b/api/everest.go
@@ -181,12 +181,23 @@ func (e *EverestServer) jwtMiddleWare(ctx context.Context) (echo.MiddlewareFunc,
 	tokenLookup := "header:Authorization:Bearer "
 	tokenLookup = tokenLookup + ",cookie:" + common.EverestTokenCookie
 	return echojwt.WithConfig(echojwt.Config{
-		Skipper: func(c echo.Context) bool {
-			return strings.Contains(c.Request().URL.Path, "session")
-		},
+		Skipper:     skipper,
 		TokenLookup: tokenLookup,
 		KeyFunc:     keyFunc,
 	}), nil
+}
+
+func skipper(c echo.Context) bool {
+	unauthorizedEndpoints := []string{
+		"/session",
+		"/settings",
+	}
+	for _, endpoint := range unauthorizedEndpoints {
+		if strings.Contains(c.Request().URL.Path, endpoint) {
+			return true
+		}
+	}
+	return false
 }
 
 // Start starts everest server.


### PR DESCRIPTION
EVEREST-1095

The settings API shouldn't be authorized since it contains the settings that are needed to start the Everest application. No sensitive data should be stored in the settings since it is stored in a ConfigMap as a plain text and exposed via an API method that doesn't require authorization. 