### PR TITLE
EVEREST-107 fix detection of the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
           git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
 
           CURRENT_STABLE_VERSION=$(yq 'select(.name == "stable-v0").entries[-1].name' veneer/everest-operator.yaml | sed 's/^everest-operator.v//')
-          CURRENT_FAST_VERSION=$(yq 'select(.name == "fast-v0").entries[-2].name' veneer/everest-operator.yaml | sed 's/^everest-operator.v//')
+          CURRENT_FAST_VERSION=$(yq 'select(.name == "fast-v0").entries[-1].name' veneer/everest-operator.yaml | sed 's/^everest-operator.v//')
 
           if [[ -z "$CURRENT_STABLE_VERSION" ]]; then
             echo "CURRENT_STABLE_VERSION is required"


### PR DESCRIPTION
Since we moved 0.0.0 to the top of the list in the veneer file, the latest version in the fast channel is the last one in the list now, but not the second last as it was before