### PR TITLE
EVEREST-1128 | Improved resiliency against update conflicts

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	goversion "github.com/hashicorp/go-version"
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -818,26 +819,40 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 	if ownerCsvIdx < 0 {
 		return fmt.Errorf("cannot find ClusterServiceVersion owner for deployment %s in namespace %s", name, namespace)
 	}
-	csv, err := k.client.GetClusterServiceVersion(ctx, types.NamespacedName{
-		Name:      deployment.GetOwnerReferences()[ownerCsvIdx].Name,
-		Namespace: namespace,
-	})
-	if err != nil {
-		return err
-	}
-	// Update restart annotation.
-	annotations := csv.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
+
 	now := time.Now().Truncate(time.Second)
-	annotations[deploymentRestartAnnotation] = now.Format(time.RFC3339)
-	csv.SetAnnotations(annotations)
-	if _, err = k.client.UpdateClusterServiceVersion(ctx, csv); err != nil {
-		return err
+	// Find the operator CSV and add the restart annotation.
+	// We retry this operatation since there may be update conflicts.
+	var b backoff.BackOff
+	b = backoff.NewConstantBackOff(3 * time.Second)
+	b = backoff.WithMaxRetries(b, 5)
+	b = backoff.WithContext(b, ctx)
+	if err := backoff.Retry(func() error {
+		csv, err := k.client.GetClusterServiceVersion(ctx, types.NamespacedName{
+			Name:      deployment.GetOwnerReferences()[ownerCsvIdx].Name,
+			Namespace: namespace,
+		})
+		if err != nil {
+			return err
+		}
+		// Update restart annotation.
+		annotations := csv.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		now = time.Now().Truncate(time.Second)
+		annotations[deploymentRestartAnnotation] = now.Format(time.RFC3339)
+		csv.SetAnnotations(annotations)
+		if _, err = k.client.UpdateClusterServiceVersion(ctx, csv); err != nil {
+			return err
+		}
+		return nil
+	}, b); err != nil {
+		return errors.Join(err, errors.New("cannot update ClusterServiceVersion with restart annotation"))
 	}
+
 	// Wait for pods to be ready.
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		deployment, err := k.GetDeployment(ctx, name, namespace)
 		if err != nil {
 			return false, err
@@ -859,29 +874,39 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 
 		return ready, nil
 	})
-	return err
 }
 
 // RestartDeployment restarts the given deployment.
 func (k *Kubernetes) RestartDeployment(ctx context.Context, name, namespace string) error {
-	// Get the deployment.
-	deployment, err := k.GetDeployment(ctx, name, namespace)
-	if err != nil {
-		return err
-	}
-	// Set restart annotation.
-	annotations := deployment.Spec.Template.Annotations
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	annotations[deploymentRestartAnnotation] = time.Now().Format(time.RFC3339)
-	deployment.Spec.Template.SetAnnotations(annotations)
-	// Update deployment.
-	if _, err := k.client.UpdateDeployment(ctx, deployment); err != nil {
-		return err
+	// Get the Deployment and add restart annotation to pod template.
+	// We retry this operatation since there may be update conflicts.
+	var b backoff.BackOff
+	b = backoff.NewConstantBackOff(3 * time.Second)
+	b = backoff.WithMaxRetries(b, 5)
+	b = backoff.WithContext(b, ctx)
+	if err := backoff.Retry(func() error {
+		// Get the deployment.
+		deployment, err := k.GetDeployment(ctx, name, namespace)
+		if err != nil {
+			return err
+		}
+		// Set restart annotation.
+		annotations := deployment.Spec.Template.Annotations
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[deploymentRestartAnnotation] = time.Now().Format(time.RFC3339)
+		deployment.Spec.Template.SetAnnotations(annotations)
+		// Update deployment.
+		if _, err := k.client.UpdateDeployment(ctx, deployment); err != nil {
+			return err
+		}
+		return nil
+	}, b); err != nil {
+		return errors.Join(err, errors.New("cannot add restart annotation to deployment"))
 	}
 	// Wait for pods to be ready.
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		deployment, err := k.GetDeployment(ctx, name, namespace)
 		if err != nil {
 			return false, err
@@ -893,7 +918,6 @@ func (k *Kubernetes) RestartDeployment(ctx context.Context, name, namespace stri
 
 		return ready, nil
 	})
-	return err
 }
 
 // ListEngineDeploymentNames returns a string array containing found engine deployments for the Everest.

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -849,7 +849,8 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 			return err
 		}
 		return nil
-	}, b); err != nil {
+	}, b,
+	); err != nil {
 		return errors.Join(err, errors.New("cannot update ClusterServiceVersion with restart annotation"))
 	}
 
@@ -879,8 +880,6 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 }
 
 // RestartDeployment restarts the given deployment.
-//
-//nolint:funlen
 func (k *Kubernetes) RestartDeployment(ctx context.Context, name, namespace string) error {
 	// Get the Deployment and add restart annotation to pod template.
 	// We retry this operatation since there may be update conflicts.
@@ -906,7 +905,8 @@ func (k *Kubernetes) RestartDeployment(ctx context.Context, name, namespace stri
 			return err
 		}
 		return nil
-	}, b); err != nil {
+	}, b,
+	); err != nil {
 		return errors.Join(err, errors.New("cannot add restart annotation to deployment"))
 	}
 	// Wait for pods to be ready.

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -806,6 +806,8 @@ func (k *Kubernetes) victoriaMetricsCRDFiles() []string {
 }
 
 // RestartOperator restarts the deployment of an operator managed by OLM.
+//
+//nolint:funlen
 func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string) error {
 	// Get the deployment.
 	deployment, err := k.GetDeployment(ctx, name, namespace)
@@ -877,6 +879,8 @@ func (k *Kubernetes) RestartOperator(ctx context.Context, name, namespace string
 }
 
 // RestartDeployment restarts the given deployment.
+//
+//nolint:funlen
 func (k *Kubernetes) RestartDeployment(ctx context.Context, name, namespace string) error {
 	// Get the Deployment and add restart annotation to pod template.
 	// We retry this operatation since there may be update conflicts.

--- a/pkg/kubernetes/kubernetes_interface.go
+++ b/pkg/kubernetes/kubernetes_interface.go
@@ -93,6 +93,8 @@ type KubernetesConnector interface {
 	// ProvisionMonitoring provisions PMM monitoring.
 	ProvisionMonitoring(namespace string) error
 	// RestartOperator restarts the deployment of an operator managed by OLM.
+	//
+	//nolint:funlen
 	RestartOperator(ctx context.Context, name, namespace string) error
 	// RestartDeployment restarts the given deployment.
 	RestartDeployment(ctx context.Context, name, namespace string) error


### PR DESCRIPTION
`RestartOperator` and `RestartDeployment` methods must retry update operations in order to improve resilience against update conflicts