### PR TITLE
EVEREST-1126 | Skip post-install message if admin password is hashed

### DIFF
--- a/pkg/accounts/types.go
+++ b/pkg/accounts/types.go
@@ -66,4 +66,5 @@ type Interface interface {
 	Delete(ctx context.Context, username string) error
 	SetPassword(ctx context.Context, username, newPassword string, secure bool) error
 	Verify(ctx context.Context, username, password string) error
+	IsSecure(ctx context.Context, username string) (bool, error)
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -221,7 +221,13 @@ func (o *Install) Run(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Fprint(os.Stdout, postInstallMessage)
+	isAdminSecure, err := o.kubeClient.Accounts().IsSecure(ctx, common.EverestAdminUser)
+	if err != nil {
+		return errors.Join(err, errors.New("could not check if the admin password is secure"))
+	}
+	if !isAdminSecure {
+		fmt.Fprint(os.Stdout, postInstallMessage)
+	}
 	return nil
 }
 


### PR DESCRIPTION
We should skip the post-install message if the admin password is already hashed after installing Everest once already.