### PR TITLE
EVEREST-1123 | Create `settings` command and move oidc under it

### DIFF
--- a/commands/accounts.go
+++ b/commands/accounts.go
@@ -25,7 +25,9 @@ import (
 
 func newAccountsCmd(l *zap.SugaredLogger) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "accounts",
+		Use:   "accounts",
+		Long:  "Manage Everest accounts",
+		Short: "Manage Everest accounts",
 	}
 
 	cmd.AddCommand(accounts.NewCreateCmd(l))

--- a/commands/install.go
+++ b/commands/install.go
@@ -37,6 +37,8 @@ func newInstallCmd(l *zap.SugaredLogger) *cobra.Command {
 		//        Error: unknown command "a" for "everestctl install"
 		Args:    cobra.NoArgs,
 		Example: "everestctl install --namespaces dev,staging,prod --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard",
+		Long:    "Install Percona Everest",
+		Short:   "Install Percona Everest",
 		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
 			initInstallViperFlags(cmd)
 			c := &install.Config{}

--- a/commands/root.go
+++ b/commands/root.go
@@ -26,7 +26,9 @@ import (
 // NewRootCmd creates a new root command for the cli.
 func NewRootCmd(l *zap.SugaredLogger) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use: "everestctl",
+		Use:   "everestctl",
+		Long:  "CLI for managing Percona Everest",
+		Short: "CLI for managing Percona Everest",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) { //nolint:revive
 			logger.InitLoggerInRootCmd(cmd, l)
 			l.Debug("Debug logging enabled")

--- a/commands/root.go
+++ b/commands/root.go
@@ -42,7 +42,7 @@ func NewRootCmd(l *zap.SugaredLogger) *cobra.Command {
 	rootCmd.AddCommand(newUpgradeCmd(l))
 	rootCmd.AddCommand(newUninstallCmd(l))
 	rootCmd.AddCommand(newAccountsCmd(l))
-	rootCmd.AddCommand(newOIDCCmd(l))
+	rootCmd.AddCommand(newSettingsCommand(l))
 
 	return rootCmd
 }

--- a/commands/settings.go
+++ b/commands/settings.go
@@ -17,9 +17,10 @@
 package commands
 
 import (
-	"github.com/percona/everest/commands/settings"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+
+	"github.com/percona/everest/commands/settings"
 )
 
 func newSettingsCommand(l *zap.SugaredLogger) *cobra.Command {

--- a/commands/settings.go
+++ b/commands/settings.go
@@ -1,0 +1,33 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands ...
+package commands
+
+import (
+	"github.com/percona/everest/commands/settings"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newSettingsCommand(l *zap.SugaredLogger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "settings",
+		Long: "Configure Everest settings",
+	}
+	cmd.AddCommand(settings.NewOIDCCmd(l))
+
+	return cmd
+}

--- a/commands/settings.go
+++ b/commands/settings.go
@@ -24,8 +24,9 @@ import (
 
 func newSettingsCommand(l *zap.SugaredLogger) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "settings",
-		Long: "Configure Everest settings",
+		Use:   "settings",
+		Long:  "Configure Everest settings",
+		Short: "Configure Everest settings",
 	}
 	cmd.AddCommand(settings.NewOIDCCmd(l))
 

--- a/commands/settings/oidc.go
+++ b/commands/settings/oidc.go
@@ -13,19 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package commands ...
-package commands
+// Package settings ...
+package settings
 
 import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
-	"github.com/percona/everest/commands/oidc"
+	"github.com/percona/everest/commands/settings/oidc"
 )
 
-func newOIDCCmd(l *zap.SugaredLogger) *cobra.Command {
+// NewOIDCCmd returns an new OIDC sub-command.
+func NewOIDCCmd(l *zap.SugaredLogger) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "oidc",
+		Use:  "oidc",
+		Long: "Configure OIDC settings",
 	}
 
 	cmd.AddCommand(oidc.NewConfigureCommand(l))

--- a/commands/settings/oidc/configure.go
+++ b/commands/settings/oidc/configure.go
@@ -58,7 +58,6 @@ func NewConfigureCommand(l *zap.SugaredLogger) *cobra.Command {
 }
 
 func initOIDCFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("kubeconfig", "k", "~/.kube/config", "Path to a kubeconfig")
 	cmd.Flags().String("issuer-url", "", "OIDC issuer url")
 	cmd.Flags().String("client-id", "", "ID of the client OIDC app")
 }

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -30,7 +30,9 @@ import (
 // newUninstallCmd returns a new uninstall command.
 func newUninstallCmd(l *zap.SugaredLogger) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "uninstall",
+		Use:   "uninstall",
+		Long:  "Uninstall Percona Everest",
+		Short: "Uninstall Percona Everest",
 		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
 			initUninstallViperFlags(cmd)
 			c, err := parseClusterConfig()

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -35,7 +35,9 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 		//       ./everestctl upgrade --namespaces=aaa, a
 		// it will return
 		//        Error: unknown command "a" for "everestctl upgrade"
-		Args: cobra.NoArgs,
+		Args:  cobra.NoArgs,
+		Long:  "Upgrade Percona Everest",
+		Short: "Upgrade Percona Everest",
 		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
 			initUpgradeViperFlags(cmd)
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -11,7 +11,9 @@ import (
 
 func newVersionCmd(l *zap.SugaredLogger) *cobra.Command {
 	return &cobra.Command{
-		Use: "version",
+		Use:   "version",
+		Long:  "Print version info",
+		Short: "Print version info",
 		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
 			outputJSON, err := cmd.Flags().GetBool("json")
 			if err != nil {


### PR DESCRIPTION
Previously we had:
```shell
$ everestctl oidc configure ...
```

Now we will have a `settings` command that manages everything related to settings, including oidc:
```shell
$ everestctl settings oidc configure ...
```

Also adds help messages for every command