### PR TITLE
EVEREST-1112 | add command for retrieving initial admin password

### DIFF
--- a/commands/accounts.go
+++ b/commands/accounts.go
@@ -33,6 +33,7 @@ func newAccountsCmd(l *zap.SugaredLogger) *cobra.Command {
 	cmd.AddCommand(accounts.NewDeleteCmd(l))
 	cmd.AddCommand(accounts.NewSetPwCommand(l))
 	cmd.AddCommand(accounts.NewResetJWTKeysCommand(l))
+	cmd.AddCommand(accounts.NewInitialAdminPasswdCommand(l))
 
 	return cmd
 }

--- a/commands/accounts/initial_admin_password.go
+++ b/commands/accounts/initial_admin_password.go
@@ -1,0 +1,59 @@
+// Package accounts holds commands for accounts command.
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/kubernetes"
+)
+
+// NewInitialAdminPasswdCommand returns a new initial-admin-passwd command.
+func NewInitialAdminPasswdCommand(l *zap.SugaredLogger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "initial-admin-password",
+		Example: "everestctl accounts initial-admin-password",
+		Long:    "Get the initial admin password for Everest",
+		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
+			viper.BindEnv("kubeconfig")                                     //nolint:errcheck,gosec
+			viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
+			kubeconfigPath := viper.GetString("kubeconfig")
+
+			k, err := kubernetes.New(kubeconfigPath, l)
+			if err != nil {
+				var u *url.Error
+				if errors.As(err, &u) {
+					l.Error("Could not connect to Kubernetes. " +
+						"Make sure Kubernetes is running and is accessible from this computer/server.")
+				}
+				os.Exit(1)
+			}
+
+			ctx := context.Background()
+			secure, err := k.Accounts().IsSecure(ctx, common.EverestAdminUser)
+			if err != nil {
+				l.Error(err)
+				os.Exit(1)
+			}
+			if secure {
+				l.Info("Cannot retrieve admin password after it has been updated.")
+				os.Exit(0)
+			}
+			admin, err := k.Accounts().Get(ctx, common.EverestAdminUser)
+			if err != nil {
+				l.Error(err)
+				os.Exit(1)
+			}
+			fmt.Fprint(os.Stdout, admin.PasswordHash+"\n")
+		},
+	}
+	return cmd
+}

--- a/commands/accounts/initial_admin_password.go
+++ b/commands/accounts/initial_admin_password.go
@@ -44,8 +44,8 @@ func NewInitialAdminPasswdCommand(l *zap.SugaredLogger) *cobra.Command {
 				os.Exit(1)
 			}
 			if secure {
-				l.Info("Cannot retrieve admin password after it has been updated.")
-				os.Exit(0)
+				l.Error("Cannot retrieve admin password after it has been updated.")
+				os.Exit(1)
 			}
 			admin, err := k.Accounts().Get(ctx, common.EverestAdminUser)
 			if err != nil {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -57,11 +57,7 @@ Everest has been successfully installed!
 
 To view the password for the 'admin' user, run the following command:
 
-kubectl get secret everest-accounts -n everest-system -o jsonpath='{.data.users\.yaml}' \
-    | base64 --decode \
-    | grep -A 5 '^admin:' \
-    | grep 'passwordHash:' \
-    | awk '{print $2}'
+everestctl accounts initial-admin-password
 
 
 IMPORTANT: This password is NOT stored in a hashed format. To secure it, update the password using the following command:


### PR DESCRIPTION
To retrieve the initial admin password, now you can run the following command:
```shell
everestctl accounts initial-admin-password
```

If the password has been reset, it shows the following error:
```shell
2024-06-06T13:20:55.427+0530    ERROR   Cannot retrieve admin password after it has been updated.```