### PR TITLE
Re-implement CompareVersions helper using generics

### DIFF
--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -2,6 +2,10 @@ package common
 
 import goversion "github.com/hashicorp/go-version"
 
+type version interface {
+	string | *goversion.Version
+}
+
 // CompareVersions compares two versions.
 // Returns:
 // -1 if v1 < v2
@@ -10,25 +14,21 @@ import goversion "github.com/hashicorp/go-version"
 //
 // Arguments can be passed either as string or *goversion.Version,
 // otherwise this function will panic.
-func CompareVersions(v1, v2 interface{}) int {
+func CompareVersions[T1, T2 version](v1 T1, v2 T2) int {
 	var ver1, ver2 *goversion.Version
 
-	switch val := v1.(type) {
+	switch val := any(v1).(type) {
 	case string:
 		ver1 = goversion.Must(goversion.NewVersion(val))
 	case *goversion.Version:
 		ver1 = val
-	default:
-		panic("v1 must be either string or *goversion.Version")
 	}
 
-	switch val := v2.(type) {
+	switch val := any(v2).(type) {
 	case string:
 		ver2 = goversion.Must(goversion.NewVersion(val))
 	case *goversion.Version:
 		ver2 = val
-	default:
-		panic("v2 must be either string or *goversion.Version")
 	}
 	return ver1.Core().Compare(ver2.Core())
 }

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -20,4 +20,5 @@ func TestCompareVersions(t *testing.T) {
 	assert.Equal(t, int(-1), CompareVersions("1.0.0", "1.1.0"))
 	assert.Equal(t, int(-1), CompareVersions("1.0.0", goversion.Must(goversion.NewVersion("1.1.0"))))
 	assert.Equal(t, int(-1), CompareVersions("1.0.0-rc1", goversion.Must(goversion.NewVersion("1.1.0"))))
+	assert.Equal(t, int(-1), CompareVersions("1.0.0-rc1", goversion.Must(goversion.NewVersion("1.1.0"))))
 }

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -20,5 +20,4 @@ func TestCompareVersions(t *testing.T) {
 	assert.Equal(t, int(-1), CompareVersions("1.0.0", "1.1.0"))
 	assert.Equal(t, int(-1), CompareVersions("1.0.0", goversion.Must(goversion.NewVersion("1.1.0"))))
 	assert.Equal(t, int(-1), CompareVersions("1.0.0-rc1", goversion.Must(goversion.NewVersion("1.1.0"))))
-	assert.Equal(t, int(-1), CompareVersions("1.0.0-rc1", goversion.Must(goversion.NewVersion("1.1.0"))))
 }


### PR DESCRIPTION
Using generics, we're able to enforce a type constraint during compile time, which can prevent possible panics that may occur due to failed/unsupported type casting.