### PR TITLE
Rephrase preflight message for DB engine upgrade

### DIFF
--- a/api/operatorupgrade_preflight.go
+++ b/api/operatorupgrade_preflight.go
@@ -84,7 +84,7 @@ func getUpgradePreflightCheckResultForDatabase(
 			Name:        pointer.To(database.GetName()),
 			PendingTask: pointer.To(OperatorUpgradePreflightForDatabasePendingTaskUpgradeEngine),
 			Message: pointer.ToString(
-				fmt.Sprintf("Upgrade DB version to at least %s", minReqVer)),
+				fmt.Sprintf("Upgrade DB version to %s or higher", minReqVer)),
 		}, nil
 	}
 

--- a/api/operatorupgrade_preflight.go
+++ b/api/operatorupgrade_preflight.go
@@ -84,7 +84,7 @@ func getUpgradePreflightCheckResultForDatabase(
 			Name:        pointer.To(database.GetName()),
 			PendingTask: pointer.To(OperatorUpgradePreflightForDatabasePendingTaskUpgradeEngine),
 			Message: pointer.ToString(
-				fmt.Sprintf("Upgrade DB version to %s", minReqVer)),
+				fmt.Sprintf("Upgrade DB version to at least %s", minReqVer)),
 		}, nil
 	}
 

--- a/api/operatorupgrade_preflight_test.go
+++ b/api/operatorupgrade_preflight_test.go
@@ -107,7 +107,7 @@ func TestGetUpgradePreflightChecks(t *testing.T) {
 		dbResult := (*result.Databases)[0]
 		assert.Equal(t, "test-db", pointer.Get(dbResult.Name))
 		assert.Equal(t, OperatorUpgradePreflightForDatabasePendingTaskUpgradeEngine, pointer.Get(dbResult.PendingTask))
-		assert.Equal(t, "Upgrade DB version to 0.5.0", pointer.Get(dbResult.Message))
+		assert.Equal(t, "Upgrade DB version to at least 0.5.0", pointer.Get(dbResult.Message))
 	})
 
 	t.Run("pending CRVersion update", func(t *testing.T) {

--- a/api/operatorupgrade_preflight_test.go
+++ b/api/operatorupgrade_preflight_test.go
@@ -107,7 +107,7 @@ func TestGetUpgradePreflightChecks(t *testing.T) {
 		dbResult := (*result.Databases)[0]
 		assert.Equal(t, "test-db", pointer.Get(dbResult.Name))
 		assert.Equal(t, OperatorUpgradePreflightForDatabasePendingTaskUpgradeEngine, pointer.Get(dbResult.PendingTask))
-		assert.Equal(t, "Upgrade DB version to at least 0.5.0", pointer.Get(dbResult.Message))
+		assert.Equal(t, "Upgrade DB version to 0.5.0 or higher", pointer.Get(dbResult.Message))
 	})
 
 	t.Run("pending CRVersion update", func(t *testing.T) {


### PR DESCRIPTION
"Upgrade DB version to at least X"

This rephrasing allows us to upgrade a DB engine from the upgrade page, by bumping to the most compatible recommended version.