### PR TITLE
EVEREST-865 allow empty username/password in PATCH monitoring-instances

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -486,7 +486,7 @@ func validateCreateMonitoringInstanceRequest(ctx echo.Context) (*CreateMonitorin
 	return &params, nil
 }
 
-//nolint:nestif,cyclop
+//nolint:nestif
 func (e *EverestServer) validateUpdateMonitoringInstanceRequest(ctx echo.Context, mc *everestv1alpha1.MonitoringConfig, monitoringConfigName string) (*UpdateMonitoringInstanceJSONRequestBody, error) {
 	var params UpdateMonitoringInstanceJSONRequestBody
 	if err := ctx.Bind(&params); err != nil {
@@ -527,10 +527,6 @@ func (e *EverestServer) validateUpdateMonitoringInstanceRequest(ctx echo.Context
 
 	if err := validateUpdateMonitoringInstanceType(params); err != nil {
 		return nil, err
-	}
-
-	if params.Pmm != nil && params.Pmm.ApiKey == "" && params.Pmm.User == "" && params.Pmm.Password == "" {
-		return nil, errors.New("one of pmm.apiKey, pmm.user or pmm.password fields is required")
 	}
 
 	return &params, nil


### PR DESCRIPTION
Since this is a PATCH method users shouldn't need to specify all parameters if they don't want to. If users don't specify the username/password we refrain from updating the secret but still update the MonitoringConfig CR.