### PR TITLE
EVEREST-1170 Add PG restrictions

### DIFF
--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -1016,3 +1016,102 @@ func TestValidateDBEngineUpgrade(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckStorageDuplicates(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		cluster []byte
+		err     error
+	}{
+		{
+			name:    "ok: no schedules no backups",
+			cluster: []byte(`{}`),
+			err:     nil,
+		},
+		{
+			name:    "ok: no duplicated storages",
+			cluster: []byte(`{"spec":{"backup":{"schedules":[{"backupStorageName":"bs1"},{"backupStorageName":"bs2"}]}}}`),
+			err:     nil,
+		},
+		{
+			name:    "error duplicated storage",
+			cluster: []byte(`{"spec":{"backup":{"schedules":[{"backupStorageName":"bs1"},{"backupStorageName":"bs2"},{"backupStorageName":"bs1"}]}}}`),
+			err:     errDuplicatedStoragePG,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			db := &DatabaseCluster{}
+			err := json.Unmarshal(tc.cluster, db)
+			require.NoError(t, err)
+			err = checkStorageDuplicates(*db)
+			if tc.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tc.err.Error(), err.Error())
+		})
+	}
+}
+
+func TestCheckSchedulesChanges(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		oldCluster []byte
+		newCluster []byte
+		err        error
+	}{
+		{
+			name:       "ok: no schedules no backups",
+			oldCluster: []byte(`{}`),
+			newCluster: []byte(`{}`),
+			err:        nil,
+		},
+		{
+			name:       "ok: added storage",
+			oldCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"}]}}}`),
+			newCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"}, {"name":"B", "backupStorageName":"bs2"}]}}}`),
+			err:        nil,
+		},
+		{
+			name:       "error: deleted storage",
+			oldCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A","backupStorageName":"bs1"},{"name":"B", "backupStorageName":"bs2"}]}}}`),
+			newCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A","backupStorageName":"bs1"}]}}}`),
+			err:        errStorageDeletionPG,
+		},
+		{
+			name:       "error: deleted storage and new added",
+			oldCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"},{"name": "B", "backupStorageName":"bs2"}]}}}`),
+			newCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"},{"name": "C", "backupStorageName":"bs2"}]}}}`),
+			err:        errStorageDeletionPG,
+		},
+		{
+			name:       "error: edited storage",
+			oldCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"},{"name": "B", "backupStorageName":"bs2"}]}}}`),
+			newCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"},{"name": "B", "backupStorageName":"bs3"}]}}}`),
+			err:        errStorageChangePG,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			newDB := &DatabaseCluster{}
+			err := json.Unmarshal(tc.newCluster, newDB)
+			require.NoError(t, err)
+			oldDB := &everestv1alpha1.DatabaseCluster{}
+			err = json.Unmarshal(tc.oldCluster, oldDB)
+			require.NoError(t, err)
+			err = checkSchedulesChanges(*oldDB, *newDB)
+			if tc.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tc.err.Error(), err.Error())
+		})
+	}
+}


### PR DESCRIPTION
EVEREST-1170

The Everest pg design issues were discovered (the initial bug EVEREST-1161). The problems appear because: 
- the repo names (`repo2`, `repo3`, `repo4`) are not sticky and when Everest edits/deletes schedules the names can shift so all the already taken backups may point out to a not relevant repo 
- repos with the same storage are being considered as the same repo in `pgbackrest`, which messes up the repo names from the pgbackrest side too (idea how to fix: use a unique path for each repo) :
<img width="1504" alt="Screenshot 2024-06-21 at 10 05 10" src="https://github.com/percona/everest/assets/91597950/eaa86e58-7aee-4001-840e-9a500653ac88">


Since it's not feasible to properly implement and test the solution before the GA, it was decided to restrict the following PG functionality until we have a proper fix in the next releases: 

For PG: 
1. Don’t allow to edit the storage in the existing schedules
2. Don’t allow to delete schedules 
3. Don’t allow to have the same storage for any 2 schedules

This PR implements the restrictions for the Everest API