### PR TITLE
API PUT DB cluster validation fix

### DIFF
--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -83,7 +83,8 @@ func (e *EverestServer) CreateDatabaseClusterBackup(ctx echo.Context, namespace 
 		return err
 	} else if !ok {
 		return ctx.JSON(http.StatusPreconditionFailed,
-			Error{Message: pointer.ToString("Cannot create a new backup when another backup is already running")})
+			Error{Message: pointer.ToString("Cannot create a new backup when another backup is already running")},
+		)
 	}
 	return e.proxyKubernetes(ctx, namespace, databaseClusterBackupKind, "")
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -843,7 +843,7 @@ func validateBackupSpec(cluster *DatabaseCluster) error {
 	if !cluster.Spec.Backup.Enabled {
 		return nil
 	}
-	if cluster.Spec.Backup.Schedules == nil {
+	if cluster.Spec.Backup.Schedules == nil || len(*cluster.Spec.Backup.Schedules) == 0 {
 		return errNoSchedules
 	}
 


### PR DESCRIPTION
Fix the validation problem:

The key factor here is the `schedules` property. If you send it empty, as long as `enabled = true` , the API will take it.
The API only throws an error if `enabled = true` but the schedule key is absent 