### PR TITLE
EVEREST-1188 fix: send schedules undefined when none present

### DIFF
--- a/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/useCreateDbCluster.ts
@@ -59,16 +59,17 @@ const formValuesToPayloadMapping = (
                 : dbPayload.pitrStorageLocation!.name,
           },
         }),
-        ...(dbPayload.schedules?.length > 0 && {
-          schedules: dbPayload.schedules.map((schedule) => ({
-            ...schedule,
-            schedule: cronConverter(
-              schedule.schedule,
-              Intl.DateTimeFormat().resolvedOptions().timeZone,
-              'UTC'
-            ),
-          })),
-        }),
+        schedules:
+          dbPayload.schedules?.length > 0
+            ? dbPayload.schedules.map((schedule) => ({
+                ...schedule,
+                schedule: cronConverter(
+                  schedule.schedule,
+                  Intl.DateTimeFormat().resolvedOptions().timeZone,
+                  'UTC'
+                ),
+              }))
+            : undefined,
       },
       engine: {
         type: dbTypeToDbEngine(dbPayload.dbType),

--- a/ui/apps/everest/src/hooks/api/db-cluster/useUpdateDbCluster.ts
+++ b/ui/apps/everest/src/hooks/api/db-cluster/useUpdateDbCluster.ts
@@ -51,16 +51,17 @@ const formValuesToPayloadOverrides = (
           enabled: dbPayload.pitrEnabled,
           backupStorageName: pitrBackupStorageName,
         },
-        ...(dbPayload.schedules?.length > 0 && {
-          schedules: dbPayload.schedules.map((schedule) => ({
-            ...schedule,
-            schedule: cronConverter(
-              schedule.schedule,
-              Intl.DateTimeFormat().resolvedOptions().timeZone,
-              'UTC'
-            ),
-          })),
-        }),
+        schedules:
+          dbPayload.schedules.length > 0
+            ? dbPayload.schedules.map((schedule) => ({
+                ...schedule,
+                schedule: cronConverter(
+                  schedule.schedule,
+                  Intl.DateTimeFormat().resolvedOptions().timeZone,
+                  'UTC'
+                ),
+              }))
+            : undefined,
       },
       engine: {
         ...dbCluster.spec.engine,


### PR DESCRIPTION
Issue: previous schedules were sent when all got emptied during cluster edition.
Cause: since schedules in the form were empty, the previous ones were being sent to the API because the override would only happen when some schedule was present.
Solution: schedules key always present. If none on the form, it's set as undefined and removed during the API request