### PR TITLE
Ensure correct managed-by label for namespaces managed by tilt

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -69,6 +69,7 @@ k8s_resource(
 namespaces = sorted([namespace['name'] for namespace in config_yaml['namespaces']])
 for namespace in namespaces:
   namespace_create(namespace)
+  local('kubectl label namespace %s app.kubernetes.io/managed-by=everest --overwrite' % namespace)
 k8s_resource(
   objects=[
     '%s:namespace' % namespace for namespace in namespaces


### PR DESCRIPTION
After merging https://github.com/percona/everest/pull/454, we changed the way we look up namespaces managed by Everest - instead of reading from the Deployment, we label namespaces with `app.kubernetes.io/managed-by=everest`, and use it to list namespaces.

However, this label is missing from namespaces managed by Tilt because they're added only during CLI install/upgrade.

This PR ensures that tilt namespaces also have this label.