### PR TITLE
EVEREST-1216 Allow PG storages removal

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -100,7 +100,6 @@ var (
 	errDBEngineDowngrade             = errors.New("database engine version cannot be downgraded")
 	errDuplicatedSchedules           = errors.New("duplicated backup schedules are not allowed")
 	errDuplicatedStoragePG           = errors.New("postgres clusters can't use the same storage for the different schedules")
-	errStorageDeletionPG             = errors.New("the existing postgres schedules can't be deleted")
 	errStorageChangePG               = errors.New("the existing postgres schedules can't change their storage")
 
 	//nolint:gochecknoglobals
@@ -677,25 +676,14 @@ func checkSchedulesChanges(oldDbc everestv1alpha1.DatabaseCluster, newDbc Databa
 		return nil
 	}
 	newSchedules := *newDbc.Spec.Backup.Schedules
-	// check the old storage wasn't deleted
-	if len(oldDbc.Spec.Backup.Schedules) > len(newSchedules) {
-		return errStorageDeletionPG
-	}
-	var found bool
 	for _, oldSched := range oldDbc.Spec.Backup.Schedules {
-		found = false
 		for _, newShed := range newSchedules {
 			// check the existing schedule storage wasn't changed
 			if oldSched.Name == newShed.Name {
-				found = true
 				if oldSched.BackupStorageName != newShed.BackupStorageName {
 					return errStorageChangePG
 				}
 			}
-		}
-		// check the old storage wasn't deleted
-		if !found {
-			return errStorageDeletionPG
 		}
 	}
 	// check there is no duplicated storages

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -1078,16 +1078,16 @@ func TestCheckSchedulesChanges(t *testing.T) {
 			err:        nil,
 		},
 		{
-			name:       "error: deleted storage",
+			name:       "ok: deleted storage",
 			oldCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A","backupStorageName":"bs1"},{"name":"B", "backupStorageName":"bs2"}]}}}`),
 			newCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A","backupStorageName":"bs1"}]}}}`),
-			err:        errStorageDeletionPG,
+			err:        nil,
 		},
 		{
-			name:       "error: deleted storage and new added",
+			name:       "ok: deleted storage and new added",
 			oldCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"},{"name": "B", "backupStorageName":"bs2"}]}}}`),
 			newCluster: []byte(`{"spec":{"backup":{"schedules":[{"name":"A", "backupStorageName":"bs1"},{"name": "C", "backupStorageName":"bs2"}]}}}`),
-			err:        errStorageDeletionPG,
+			err:        nil,
 		},
 		{
 			name:       "error: edited storage",


### PR DESCRIPTION
EVEREST-1216 
The [investigation](https://docs.google.com/spreadsheets/d/1UHWKdP6Rlgkir03-W5g5Ky2oFTu2aNs5p1awbyfRo4M/edit?gid=0#gid=0) revealed that the schedules deletion causes the messed up PG repos only when Everest allows to use the same storage (url + bucket + region) for several schedules, which is not allowed anymore, so we can get rid of the limitation. 


