### PR TITLE
EVEREST-1233 | Fix order of checks for dbengine version upgrades

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -1053,6 +1053,10 @@ func validateDBEngineVersionUpgrade(newVersion, oldVersion string) error {
 		return errInvalidVersion
 	}
 
+	// We will not allow downgrades.
+	if semver.Compare(newVersion, oldVersion) < 0 {
+		return errDBEngineDowngrade
+	}
 	// We will not allow major upgrades.
 	// Major upgrades are handled differently for different operators, so for now we simply won't allow it.
 	// For example:
@@ -1061,10 +1065,6 @@ func validateDBEngineVersionUpgrade(newVersion, oldVersion string) error {
 	// - PG operator does not allow major upgrades.
 	if semver.Major(oldVersion) != semver.Major(newVersion) {
 		return errDBEngineMajorVersionUpgrade
-	}
-	// We will not allow downgrades.
-	if semver.Compare(newVersion, oldVersion) < 0 {
-		return errDBEngineDowngrade
 	}
 	return nil
 }

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -1007,6 +1007,12 @@ func TestValidateDBEngineUpgrade(t *testing.T) {
 			newVersion: "v8.0.23",
 			err:        nil,
 		},
+		{
+			name:       "major version downgrade",
+			oldVersion: "16.1",
+			newVersion: "15.5",
+			err:        errDBEngineDowngrade,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
While trying to downgrade a major version returns incorrect error message - `Database engine cannot be upgraded to a major version`

With this PR, we first ensure that no downgrades are happening (major or minor) and then proceed to check for major version upgrade.