### PR TITLE
EVEREST-1142 | RBAC stability improvements

### DIFF
--- a/pkg/rbac/testdata/policy-7-bad.csv
+++ b/pkg/rbac/testdata/policy-7-bad.csv
@@ -1,0 +1,4 @@
+p, adminrole:role, namespaces, read, *
+p, adminrole:role, database-engines, *, */*
+a, adminrole:role, database-clusters, *, */*
+

--- a/pkg/rbac/utils/utils.go
+++ b/pkg/rbac/utils/utils.go
@@ -36,6 +36,9 @@ func LoadPolicyLine(line string, m model.Model) error {
 	if len(tokens) < numFieldsPolicyLine {
 		return fmt.Errorf("invalid policy line '%s'", line)
 	}
+	if tokens[0] != "p" && tokens[0] != "g" {
+		return fmt.Errorf("invalid policy line '%s'", line)
+	}
 
 	return persist.LoadPolicyArray(tokens, m)
 }

--- a/pkg/rbac/validate.go
+++ b/pkg/rbac/validate.go
@@ -43,13 +43,13 @@ func validatePolicy(enforcer *casbin.Enforcer) error {
 func ValidatePolicy(
 	ctx context.Context,
 	k *kubernetes.Kubernetes,
-	filepath string) error {
+	filepath string,
+) error {
 	enforcer, err := newKubeOrFileEnforcer(ctx, k, filepath)
 	if err != nil {
 		return errors.Join(errPolicySyntax, err)
 	}
 	return validatePolicy(enforcer)
-
 }
 
 func checkResourceNames(policies [][]string) error {

--- a/pkg/rbac/validate.go
+++ b/pkg/rbac/validate.go
@@ -17,13 +17,7 @@ import (
 // ErrPolicySyntax is returned when a policy has a syntax error.
 var errPolicySyntax = errors.New("policy syntax error")
 
-// ValidatePolicy validates a policy from either Kubernetes or local file.
-func ValidatePolicy(ctx context.Context, k *kubernetes.Kubernetes, filepath string) error {
-	enforcer, err := newKubeOrFileEnforcer(ctx, k, filepath)
-	if err != nil {
-		return errors.Join(errPolicySyntax, err)
-	}
-
+func validatePolicy(enforcer *casbin.Enforcer) error {
 	// check basic policy syntax.
 	policy := enforcer.GetPolicy()
 	for _, policy := range policy {
@@ -43,6 +37,19 @@ func ValidatePolicy(ctx context.Context, k *kubernetes.Kubernetes, filepath stri
 		return errors.Join(errPolicySyntax, err)
 	}
 	return nil
+}
+
+// ValidatePolicy validates a policy from either Kubernetes or local file.
+func ValidatePolicy(
+	ctx context.Context,
+	k *kubernetes.Kubernetes,
+	filepath string) error {
+	enforcer, err := newKubeOrFileEnforcer(ctx, k, filepath)
+	if err != nil {
+		return errors.Join(errPolicySyntax, err)
+	}
+	return validatePolicy(enforcer)
+
 }
 
 func checkResourceNames(policies [][]string) error {

--- a/pkg/rbac/validate_test.go
+++ b/pkg/rbac/validate_test.go
@@ -33,6 +33,14 @@ func TestValidatePolicy(t *testing.T) {
 			path: "./testdata/policy-5-bad.csv",
 			err:  errPolicySyntax,
 		},
+		{
+			path: "./testdata/policy-6-bad.csv",
+			err:  errPolicySyntax,
+		},
+		{
+			path: "./testdata/policy-7-bad.csv",
+			err:  errPolicySyntax,
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
The casbin library we're using lacks proper error handling, and we need to manually add checks for different types of syntax errors. This PR makes the following changes:

- Detect when a policy does not start with `p` or `g`. Earlier this leads to a panic from the casbin library, now we add a check for this so that we have proper error messages.
- Panic everest API when it detects invalid policies. Earlier, Everest was allowed to run with faulty policies. The casbin library simply skipped invalid policy lines and ran with the rest of the config. This can be problematic because now Everest has incomplete RBAC and this may have security implication because the user has no idea about it. With this PR, Everest will now panic when you enter invalid RBAC.
  - We should document that it is recommended to validate and test RBAC policies first, before applying it.