### PR TITLE
EVEREST-1235 | [CLI] Fix broken pretty print

### DIFF
--- a/cli-tests/tests/flow/all-operators.spec.ts
+++ b/cli-tests/tests/flow/all-operators.spec.ts
@@ -65,7 +65,7 @@ test.describe('Everest CLI install', async () => {
       );
 
       await out.assertSuccess();
-      await out.outErrContainsNormalizedMany([
+      await out.outContainsNormalizedMany([
         '✓ Install Operator Lifecycle Manager',
         '✓ Install Percona OLM Catalog',
         '✓ Create namespace \'everest-monitoring\'',

--- a/cli-tests/tests/flow/all-operators.spec.ts
+++ b/cli-tests/tests/flow/all-operators.spec.ts
@@ -73,7 +73,7 @@ test.describe('Everest CLI install', async () => {
         '✓ Provision monitoring stack',
         '✓ Create namespace \'everest-all\'',
         '✓ Install operators [pxc, psmdb, pg] in namespace \'everest-all\'',
-        '✓ Configure RBAC in namespace \'everest\'',
+        '✓ Configure RBAC in namespace \'everest-all\'',
         '✓ Install Everest Operator',
         '✓ Install Everest API server',
       ]);

--- a/cli-tests/tests/flow/all-operators.spec.ts
+++ b/cli-tests/tests/flow/all-operators.spec.ts
@@ -56,9 +56,29 @@ test.describe('Everest CLI install', async () => {
         'everest-operator operator has been installed',
       ]);
     });
-
     await page.waitForTimeout(10_000);
+    await verifyClusterResources();
 
+    await test.step('run everest install command (pretty))', async () => {
+      const out = await cli.everestExecSkipWizard(
+        `install --namespaces=everest-all`,
+      );
+
+      await out.assertSuccess();
+      await out.outErrContainsNormalizedMany([
+        '✓ Install Operator Lifecycle Manager',
+        '✓ Install Percona OLM Catalog',
+        '✓ Create namespace \'everest-monitoring\'',
+        '✓ Install VictoriaMetrics Operator',
+        '✓ Provision monitoring stack',
+        '✓ Create namespace \'everest-all\'',
+        '✓ Install operators [pxc, psmdb, pg] in namespace \'everest-all\'',
+        '✓ Configure RBAC in namespace \'everest\'',
+        '✓ Install Everest Operator',
+        '✓ Install Everest API server',
+      ]);
+    });
+    await page.waitForTimeout(10_000);
     await verifyClusterResources();
 
     await test.step('uninstall Everest', async () => {

--- a/cli-tests/tests/flow/mongodb-operator.spec.ts
+++ b/cli-tests/tests/flow/mongodb-operator.spec.ts
@@ -58,9 +58,29 @@ test.describe('Everest CLI install', async () => {
         'everest-operator operator has been installed',
       ]);
     });
-
     await page.waitForTimeout(10_000);
+    await verifyClusterResources();
 
+    await test.step('run everest install command (pretty))', async () => {
+      const out = await cli.everestExecSkipWizard(
+        `install --operator.mongodb=true --operator.postgresql=false --operator.xtradb-cluster=false --namespaces=everest-operators`,
+      );
+
+      await out.assertSuccess();
+      await out.outContainsNormalizedMany([
+        '✓ Install Operator Lifecycle Manager',
+        '✓ Install Percona OLM Catalog',
+        '✓ Create namespace \'everest-monitoring\'',
+        '✓ Install VictoriaMetrics Operator',
+        '✓ Provision monitoring stack',
+        '✓ Create namespace \'everest-operators\'',
+        '✓ Install operators [psmdb] in namespace \'everest-operators\'',
+        '✓ Configure RBAC in namespace \'everest-operators\'',
+        '✓ Install Everest Operator',
+        '✓ Install Everest API server',
+      ]);
+    });
+    await page.waitForTimeout(10_000);
     await verifyClusterResources();
   });
 });

--- a/cli-tests/tests/flow/pg-operator.spec.ts
+++ b/cli-tests/tests/flow/pg-operator.spec.ts
@@ -57,9 +57,29 @@ test.describe('Everest CLI install', async () => {
         'everest-operator operator has been installed',
       ]);
     });
-
     await page.waitForTimeout(10_000);
+    await verifyClusterResources();
 
+    await test.step('run everest install command (pretty))', async () => {
+      const out = await cli.everestExecSkipWizard(
+        `install --operator.mongodb=false --operator.postgresql=true --operator.xtradb-cluster=false --namespaces=everest-operators`,
+      );
+
+      await out.assertSuccess();
+      await out.outContainsNormalizedMany([
+        '✓ Install Operator Lifecycle Manager',
+        '✓ Install Percona OLM Catalog',
+        '✓ Create namespace \'everest-monitoring\'',
+        '✓ Install VictoriaMetrics Operator',
+        '✓ Provision monitoring stack',
+        '✓ Create namespace \'everest-operators\'',
+        '✓ Install operators [pg] in namespace \'everest-operators\'',
+        '✓ Configure RBAC in namespace \'everest-operators\'',
+        '✓ Install Everest Operator',
+        '✓ Install Everest API server',
+      ]);
+    });
+    await page.waitForTimeout(10_000);
     await verifyClusterResources();
 
     await test.step('re-run everest install command', async () => {

--- a/cli-tests/tests/flow/pxc-operator.spec.ts
+++ b/cli-tests/tests/flow/pxc-operator.spec.ts
@@ -58,9 +58,29 @@ test.describe('Everest CLI install', async () => {
         'everest-operator operator has been installed',
       ]);
     });
-
     await page.waitForTimeout(10_000);
+    await verifyClusterResources();
 
+    await test.step('run everest install command (pretty))', async () => {
+      const out = await cli.everestExecSkipWizard(
+        `install --operator.mongodb=false --operator.postgresql=false --operator.xtradb-cluster=true --namespaces=everest-operators`,
+      );
+
+      await out.assertSuccess();
+      await out.outContainsNormalizedMany([
+        '✓ Install Operator Lifecycle Manager',
+        '✓ Install Percona OLM Catalog',
+        '✓ Create namespace \'everest-monitoring\'',
+        '✓ Install VictoriaMetrics Operator',
+        '✓ Provision monitoring stack',
+        '✓ Create namespace \'everest-operators\'',
+        '✓ Install operators [pxc] in namespace \'everest-operators\'',
+        '✓ Configure RBAC in namespace \'everest-operators\'',
+        '✓ Install Everest Operator',
+        '✓ Install Everest API server',
+      ]);
+    });
+    await page.waitForTimeout(10_000);
     await verifyClusterResources();
   });
 });

--- a/commands/install.go
+++ b/commands/install.go
@@ -47,17 +47,14 @@ func newInstallCmd(l *zap.SugaredLogger) *cobra.Command {
 				os.Exit(1)
 			}
 
+			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
+			c.Pretty = !enableLogging
+
 			op, err := install.NewInstall(*c, l, cmd)
 			if err != nil {
 				l.Error(err)
 				os.Exit(1)
 			}
-
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			if !enableLogging {
-				l = zap.NewNop().Sugar()
-			}
-			c.Pretty = !enableLogging
 
 			if err := op.Run(cmd.Context()); err != nil {
 				output.PrintError(err, l, !enableLogging)

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -40,17 +40,14 @@ func newUninstallCmd(l *zap.SugaredLogger) *cobra.Command {
 				os.Exit(1)
 			}
 
+			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
+			c.Pretty = !enableLogging
+
 			op, err := uninstall.NewUninstall(*c, l)
 			if err != nil {
 				l.Error(err)
 				os.Exit(1)
 			}
-
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			if !enableLogging {
-				l = zap.NewNop().Sugar()
-			}
-			c.Pretty = !enableLogging
 
 			if err := op.Run(cmd.Context()); err != nil {
 				output.PrintError(err, l, !enableLogging)

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -46,17 +46,14 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 				os.Exit(1)
 			}
 
+			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
+			c.Pretty = !enableLogging
+
 			op, err := upgrade.NewUpgrade(c, l)
 			if err != nil {
 				l.Error(err)
 				os.Exit(1)
 			}
-
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			if !enableLogging {
-				l = zap.NewNop().Sugar()
-			}
-			c.Pretty = !enableLogging
 
 			if err := op.Run(cmd.Context()); err != nil {
 				output.PrintError(err, l, !enableLogging)

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -169,12 +169,15 @@ func NewInstall(c Config, l *zap.SugaredLogger, cmd *cobra.Command) (*Install, e
 		cmd:    cmd,
 		l:      l.With("component", "install"),
 	}
+	if c.Pretty {
+		cli.l = zap.NewNop().Sugar()
+	}
 
 	k, err := kubernetes.New(c.KubeconfigPath, cli.l)
 	if err != nil {
 		var u *url.Error
 		if errors.As(err, &u) {
-			cli.l.Error("Could not connect to Kubernetes. " +
+			l.Error("Could not connect to Kubernetes. " +
 				"Make sure Kubernetes is running and is accessible from this computer/server.")
 		}
 		return nil, err

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -124,12 +124,15 @@ func NewUpgrade(cfg *Config, l *zap.SugaredLogger) (*Upgrade, error) {
 		config: cfg,
 		l:      l.With("component", "upgrade"),
 	}
+	if cfg.Pretty {
+		cli.l = zap.NewNop().Sugar()
+	}
 
 	k, err := kubernetes.New(cfg.KubeconfigPath, cli.l)
 	if err != nil {
 		var u *url.Error
 		if errors.As(err, &u) {
-			cli.l.Error("Could not connect to Kubernetes. " +
+			l.Error("Could not connect to Kubernetes. " +
 				"Make sure Kubernetes is running and is accessible from this computer/server.")
 		}
 		return nil, err


### PR DESCRIPTION
Follow up for https://github.com/percona/everest/pull/505 which broke the pretty printing in the CLI

- Originally https://github.com/percona/everest/pull/505 was intended to fix the Kubernetes connectivity errors not being logged on the CLI before starting the main install/upgrade/uninstall process, but it also broke the pretty printing logic. This PR ensures that pretty printing still works while the Kubernetes errors are also still being logged by our logger.
- Adds CLI tests for pretty output