### PR TITLE
[UI] EVEREST-1249 Fix Tooltip for disabled copy button not showing up

### DIFF
--- a/ui/packages/ui-lib/src/buttons/copy-to-clipboard-button/CopyToClipboardButton.tsx
+++ b/ui/packages/ui-lib/src/buttons/copy-to-clipboard-button/CopyToClipboardButton.tsx
@@ -3,6 +3,7 @@ import { Button, IconButton } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
 import { CopyToClipboardButtonProps } from './CopyToClipboardButton.types';
+import { Messages } from './clipboard.messages';
 
 const CopyToClipboardButton = ({
   textToCopy,
@@ -36,11 +37,7 @@ const CopyToClipboardButton = ({
       PopperProps={{
         disablePortal: true,
       }}
-      title={
-        clipboardAvailable
-          ? 'Copied to clipboard!'
-          : 'Clipboard access is restricted in unsecured contexts. Switch to HTTPS or localhost, or copy the content manually.'
-      }
+      title={clipboardAvailable ? Messages.copied : Messages.restrictedAccess}
     >
       {showCopyButtonText ? (
         <Button
@@ -53,20 +50,22 @@ const CopyToClipboardButton = ({
           {copyCommand}
         </Button>
       ) : (
-        <IconButton
-          component="div"
-          sx={{
-            ...buttonProps?.sx,
-            '&.Mui-disabled': {
-              pointerEvents: 'auto',
-            },
-          }}
-          onClick={handleClick}
-          disabled={!clipboardAvailable}
-          {...buttonProps}
-        >
-          <ContentCopyOutlinedIcon sx={iconSx} />
-        </IconButton>
+        <span>
+          <IconButton
+            component="div"
+            sx={{
+              ...buttonProps?.sx,
+              '&.Mui-disabled': {
+                pointerEvents: 'auto',
+              },
+            }}
+            onClick={handleClick}
+            disabled={!clipboardAvailable}
+            {...buttonProps}
+          >
+            <ContentCopyOutlinedIcon sx={iconSx} />
+          </IconButton>
+        </span>
       )}
     </Tooltip>
   );

--- a/ui/packages/ui-lib/src/buttons/copy-to-clipboard-button/clipboard.messages.ts
+++ b/ui/packages/ui-lib/src/buttons/copy-to-clipboard-button/clipboard.messages.ts
@@ -1,0 +1,5 @@
+export const Messages = {
+  copied: 'Copied to clipboard!',
+  restrictedAccess:
+    'Clipboard access is restricted in unsecured contexts. Switch to HTTPS or localhost, or copy the content manually.',
+};


### PR DESCRIPTION
[EVEREST-1249](https://perconadev.atlassian.net/browse/EVEREST-1249)

![image](https://github.com/user-attachments/assets/e0cab253-d131-485b-bfa4-80f522be6d56)


[EVEREST-1249]: https://perconadev.atlassian.net/browse/EVEREST-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ