### PR TITLE
EVEREST-1325 | CheckConstraint helper function should check only the core (ignore meta tags)

### DIFF
--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -74,7 +74,7 @@ func CheckConstraint[V version](v V, c string) bool {
 	if err != nil {
 		panic(err)
 	}
-	return constraint.Check(ver)
+	return constraint.Check(ver.Core())
 }
 
 // NewSupportedVersion returns a new SupportedVersion struct.

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -32,4 +32,8 @@ func TestCheckConstraints(t *testing.T) {
 	assert.False(t, CheckConstraint("1.0.0", "< 1.0.0"))
 	assert.True(t, CheckConstraint("1.1.0", "~> 1.1.0"))
 	assert.False(t, CheckConstraint("1.2.0", "~> 1.1.0"))
+	assert.True(t, CheckConstraint("1.2.0-rc1", "~> 1.2.0"))
+	assert.True(t, CheckConstraint("1.2.1-rc1", "~> 1.2.0"))
+	assert.False(t, CheckConstraint("1.3.1-rc1", "~> 1.2.0"))
+	assert.True(t, CheckConstraint("1.3.1-rc1", "> 1.2.0"))
 }


### PR DESCRIPTION
- This helper method is used to determine which post-upgrade task to run, depending on the upgrade version.
- Does not work correctly when `-rc` meta tag is provided
- We fix this so that post-upgrade automation can be verified using RC CLI binary as well.