### PR TITLE
EVEREST-107 update IMAGE_TAG_OWNER

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,15 @@ jobs:
               exit 1
             fi
           
+            # update IMAGE_TAG_OWNER in the Makefile to point to a correct org
+            if [[ $IS_RC == 1 ]]; then 
+              # if the RC build is being run over a Release build, there will be the "percona" org mentioned in the quickstart file, 
+              # so we should replace the org
+              sed -i "s/IMAGE_TAG_OWNER ?= docker.io\/percona\$/IMAGE_TAG_OWNER ?= docker.io\/perconalab/g" Makefile 
+            else
+              sed -i "s/IMAGE_TAG_OWNER ?= docker.io\/perconalab/IMAGE_TAG_OWNER ?= docker.io\/percona/g" Makefile 
+            fi 
+            
             make init
             make release
 


### PR DESCRIPTION
**Problem:**
After the 1.1.0 release it turned out that Everest still installs the everest-operator image from `perconalab`:
```
$ kubectl get po -l app.kubernetes.io/name=everest-operator -o yaml -n everest-system | grep image
...
image: docker.io/perconalab/everest-operator:1.1.0
```
**Cause:**
There is this [make bundle](https://github.com/percona/everest-operator/blob/110cb964dedb09bb9e3c0b7411ec00a7e48804c6/Makefile#L246-L250) command which is used during the operator release. This command uses 
the [IMG](https://github.com/percona/everest-operator/blob/110cb964dedb09bb9e3c0b7411ec00a7e48804c6/Makefile#L55) variable, which uses 
the [IMAGE_TAG_BASE](https://github.com/percona/everest-operator/blob/110cb964dedb09bb9e3c0b7411ec00a7e48804c6/Makefile#L33) variable, which uses 
the [IMAGE_TAG_OWNER](https://github.com/percona/everest-operator/blob/110cb964dedb09bb9e3c0b7411ec00a7e48804c6/Makefile#L32) variable, which was always set to `perconalab` 
and as a result [config/manager/kustomization.yaml](https://github.com/percona/everest-operator/blob/110cb964dedb09bb9e3c0b7411ec00a7e48804c6/config/manager/kustomization.yaml#L7) is always linked to `perconalab`

**Solution:**
Update the Makefile during the release so that depending on the build type (RC or Release) the `IMAGE_TAG_OWNER` would point to `perconalab` or `percona`