### PR TITLE
EVEREST-107 Tiltfile VM operator fix

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -226,6 +226,7 @@ helm_remote('victoria-metrics-operator',
   repo_name='vm',
   repo_url='https://victoriametrics.github.io/helm-charts/',
   namespace=everest_monitoring_namespace,
+  version='0.33.6',
 )
 k8s_yaml(namespace_inject('%s/data/crds/victoriametrics/kube-state-metrics.yaml' % cli_dir, everest_monitoring_namespace))
 k8s_yaml(namespace_inject('%s/data/crds/victoriametrics/crs/vmagent_rbac_account.yaml' % cli_dir, everest_monitoring_namespace))


### PR DESCRIPTION
The latest version of `victoria-metrics-operator` 0.34.0 (15 Aug, 2024) doesn't work with the current Tilt configuration.
```
Error in helm: command "helm template victoria-metrics-operator \"/Users/oxanagrishchenko/Library/Application Support/tilt-dev/.helm/vm/latest/victoria-metrics-operator\" --namespace everest-monitoring --include-crds" failed.
error: exit status 1
stdout: ""
stderr: "Error: template: victoria-metrics-operator/templates/deployment.yaml:99:30: executing \"victoria-metrics-operator/templates/deployment.yaml\" at <include \"vm.probe\" (dict \"app\" .Values \"type\" \"readiness\")>: error calling include: template: victoria-metrics-operator/charts/victoria-metrics-common/templates/_probe.tpl:6:4: executing \"vm.probe\" at <tpl (toYaml $probe) .>: error calling tpl: cannot retrieve Template.Basepath from values inside tpl function: failureThreshold: 3\nhttpGet:\n  path: '{{ include \"vm.probe.http.path\" . }}'\n  port: probe\n  scheme: '{{ include \"vm.probe.http.scheme\" . }}'\ninitialDelaySeconds: 5\nperiodSeconds: 15\ntimeoutSeconds: 5: \"BasePath\" is not a value\n\nUse --debug flag to render out invalid YAML\n"
```

Tried to use the latest version from everest-catalog - 0.29.1 it also doesn't work, with different errors.
Sticking to the previous version (0.33.6) helps. 