### PR TITLE
EVEREST-1386 | Filter ListNamespaces based on RBAC permissions

### DIFF
--- a/api/namespace.go
+++ b/api/namespace.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/AlekSi/pointer"
 	"github.com/labstack/echo/v4"
+	"github.com/percona/everest/pkg/rbac"
 )
 
 // ListNamespaces returns the current version information.
@@ -16,5 +18,34 @@ func (e *EverestServer) ListNamespaces(ctx echo.Context) error {
 			Message: pointer.ToString("Failed to list namespaces"),
 		})
 	}
-	return ctx.JSON(http.StatusOK, namespaces)
+	// Filter out result based on permission.
+	result := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if can, err := e.canReadNamespace(ctx, ns); err != nil {
+			e.l.Error(err)
+			return ctx.JSON(http.StatusInternalServerError, Error{
+				Message: pointer.ToString("Failed to check namespace permission"),
+			})
+		} else if can {
+			result = append(result, ns)
+		}
+	}
+	return ctx.JSON(http.StatusOK, result)
+}
+
+// canReadNamespace checks if the user has permission to read the namespace.
+func (e *EverestServer) canReadNamespace(ctx echo.Context, namespace string) (bool, error) {
+	user, err := rbac.GetUser(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to GetUser: %w", err)
+	}
+	ok, err := e.rbacEnforcer.Enforce(
+		user, rbac.ResourceNamespaces,
+		rbac.ActionRead,
+		namespace,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to Enforce: %w", err)
+	}
+	return ok, nil
 }

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AlekSi/pointer"
 	"github.com/labstack/echo/v4"
+
 	"github.com/percona/everest/pkg/rbac"
 )
 

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -44,6 +44,7 @@ import (
 
 // Everest API resource names.
 const (
+	ResourceNamespaces              = "namespaces"
 	ResourceDatabaseClusterBackups  = "database-cluster-backups"
 	ResourceDatabaseClusterRestores = "database-cluster-restores"
 )
@@ -212,8 +213,9 @@ func NewEnforceHandler(basePath string, enforcer *casbin.Enforcer) func(c echo.C
 		}
 		switch resource {
 		case "namespaces":
-			name := c.Param("name")
-			object = name
+			// Always allow this operation to list namespaces,
+			// however, we filter the result based on permission.
+			return true, nil
 		default:
 			namespace := c.Param("namespace")
 			name := c.Param("name")


### PR DESCRIPTION
**Problem**
After implementing RBAC, `GET /v1/namespaces` works only if you have permssions to read all (*) namepaces. A user should be able to use this API even if they have restricted access to the namespaces.

**Solution**
Always allow the `GET /v1/namespaces` operation, however the result itself is filtered based on the RBAC.