### PR TITLE
[CI] Fix broken Minikube

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -258,6 +258,12 @@ jobs:
           insecure-registry: 'localhost:5000'
           start-args: '--base-image=docker.io/kicbase/stable:v0.0.44'
 
+      # This is a temporary workaround to fix the registry-proxy image in the minikube registry.
+      # See: https://github.com/kubernetes/minikube/issues/19535
+      - name: Patch registry addon image
+        run: |
+          kubectl get daemonsets.apps -n kube-system registry-proxy -ojson | jq -r '.spec.template.spec.containers[0].image = "gcr.io/google_containers/kube-registry-proxy:0.4"' | kubectl apply -f -
+
       - name: Expose local registry
         run: |
           kubectl port-forward --namespace kube-system service/registry 5000:80 &

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -262,6 +262,7 @@ jobs:
       - name: Patch registry addon image
         run: |
           kubectl get daemonsets.apps -n kube-system registry-proxy -ojson | jq -r '.spec.template.spec.containers[0].image = "gcr.io/google_containers/kube-registry-proxy:0.4"' | kubectl apply -f -
+          kubectl rollout -n kube-system status daemonset/registry-proxy --timeout=120s
 
       - name: Expose local registry
         run: |

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -256,6 +256,7 @@ jobs:
           memory: 2000m
           addons: registry
           insecure-registry: 'localhost:5000'
+          start-args: '--base-image=docker.io/kicbase/stable:v0.0.44'
 
       - name: Expose local registry
         run: |

--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -256,7 +256,6 @@ jobs:
           memory: 2000m
           addons: registry
           insecure-registry: 'localhost:5000'
-          start-args: '--base-image=docker.io/kicbase/stable:v0.0.44'
 
       # This is a temporary workaround to fix the registry-proxy image in the minikube registry.
       # See: https://github.com/kubernetes/minikube/issues/19535


### PR DESCRIPTION
Minikube images have mysteriously disappeared, and as a result the registry addon cannot be enabled, resulting in CI failures.

Temporary workaround based on this issue thread: https://github.com/kubernetes/minikube/issues/19535