### PR TITLE
EVEREST-1403 | Run 1.2.0 API migration as a part of the post-upgrade step

### DIFF
--- a/pkg/upgrade/migrate_shared_resources.go
+++ b/pkg/upgrade/migrate_shared_resources.go
@@ -106,21 +106,20 @@ func (u *Upgrade) migrateBackupStorages(ctx context.Context) error {
 				return fmt.Errorf("cannot create backup storage %s in namespace %s", bsClone.GetName(), ns)
 			}
 
-			// Remove the Secret clean-up finalizer from the original BackupStorage.
-			// The purpose of this finalizer is to remove all Secrets linked to this BS, in the DB namespaces.
-			// After this migration, these Secrets are owned by the newly created BackupStorage in the target namespace.
-			finalizers := make([]string, 0, len(bs.GetFinalizers()))
-			for _, f := range bs.GetFinalizers() {
-				if f == backupStorageCleanupFinalizer {
-					continue
-				}
-				finalizers = append(finalizers, f)
+		}
+		// Remove the Secret clean-up finalizer from the original BackupStorage.
+		// The purpose of this finalizer is to remove all Secrets linked to this BS, in the DB namespaces.
+		// After this migration, these Secrets are owned by the newly created BackupStorage in the target namespace.
+		finalizers := make([]string, 0, len(bs.GetFinalizers()))
+		for _, f := range bs.GetFinalizers() {
+			if f == backupStorageCleanupFinalizer {
+				continue
 			}
-			bs.SetFinalizers(finalizers)
-			if err := u.kubeClient.UpdateBackupStorage(ctx, &bs); err != nil {
-				return fmt.Errorf("cannot remove finalizer %s from backup storage %s", backupStorageCleanupFinalizer, bs.Name)
-			}
-			return nil
+			finalizers = append(finalizers, f)
+		}
+		bs.SetFinalizers(finalizers)
+		if err := u.kubeClient.UpdateBackupStorage(ctx, &bs); err != nil {
+			return fmt.Errorf("cannot remove finalizer %s from backup storage %s", backupStorageCleanupFinalizer, bs.Name)
 		}
 	}
 	return nil

--- a/pkg/upgrade/migrate_shared_resources.go
+++ b/pkg/upgrade/migrate_shared_resources.go
@@ -105,7 +105,6 @@ func (u *Upgrade) migrateBackupStorages(ctx context.Context) error {
 			if err := u.kubeClient.CreateBackupStorage(ctx, bsClone); client.IgnoreAlreadyExists(err) != nil {
 				return fmt.Errorf("cannot create backup storage %s in namespace %s", bsClone.GetName(), ns)
 			}
-
 		}
 		// Remove the Secret clean-up finalizer from the original BackupStorage.
 		// The purpose of this finalizer is to remove all Secrets linked to this BS, in the DB namespaces.

--- a/pkg/upgrade/migrate_shared_resources.go
+++ b/pkg/upgrade/migrate_shared_resources.go
@@ -111,6 +111,7 @@ func (u *Upgrade) migrateBackupStorages(ctx context.Context) error {
 		// The purpose of this finalizer is to remove all Secrets linked to this BS, in the DB namespaces.
 		// After this migration, these Secrets are owned by the newly created BackupStorage in the target namespace.
 		finalizers := make([]string, 0, len(bs.GetFinalizers()))
+		u.l.Infof("Initial finalizers=%v", bs.GetFinalizers())
 		for _, f := range bs.GetFinalizers() {
 			if f == backupStorageCleanupFinalizer {
 				continue
@@ -118,6 +119,7 @@ func (u *Upgrade) migrateBackupStorages(ctx context.Context) error {
 			finalizers = append(finalizers, f)
 		}
 		bs.SetFinalizers(finalizers)
+		u.l.Infof("Updated finalizers=%v", finalizers)
 		if err := u.kubeClient.UpdateBackupStorage(ctx, &bs); err != nil {
 			return fmt.Errorf("cannot remove finalizer %s from backup storage %s", backupStorageCleanupFinalizer, bs.Name)
 		}

--- a/pkg/upgrade/migrate_shared_resources.go
+++ b/pkg/upgrade/migrate_shared_resources.go
@@ -111,7 +111,6 @@ func (u *Upgrade) migrateBackupStorages(ctx context.Context) error {
 		// The purpose of this finalizer is to remove all Secrets linked to this BS, in the DB namespaces.
 		// After this migration, these Secrets are owned by the newly created BackupStorage in the target namespace.
 		finalizers := make([]string, 0, len(bs.GetFinalizers()))
-		u.l.Infof("Initial finalizers=%v", bs.GetFinalizers())
 		for _, f := range bs.GetFinalizers() {
 			if f == backupStorageCleanupFinalizer {
 				continue
@@ -119,7 +118,6 @@ func (u *Upgrade) migrateBackupStorages(ctx context.Context) error {
 			finalizers = append(finalizers, f)
 		}
 		bs.SetFinalizers(finalizers)
-		u.l.Infof("Updated finalizers=%v", finalizers)
 		if err := u.kubeClient.UpdateBackupStorage(ctx, &bs); err != nil {
 			return fmt.Errorf("cannot remove finalizer %s from backup storage %s", backupStorageCleanupFinalizer, bs.Name)
 		}


### PR DESCRIPTION
In https://github.com/percona/everest/pull/632 we added some code to remove a finalizer from BackupStorages in `everest-system` namespace to unblock uninstallation. However, that code is run before the operator has upgraded. As a result, the operator adds back this finalizer.

To fix this problem, we run the migration after the Everest operator upgrade step, i.e, as a part of the post-upgrade tasks.