### PR TITLE
EVEREST-1404.2 Update sharding validation

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -61,7 +61,7 @@ const (
 	maxNameLength       = 22
 	timeoutS3AccessSec  = 2
 	minShardsNum        = 1
-	minConfigServersNum = 3
+	minConfigServersNum = 1
 )
 
 var (
@@ -112,7 +112,7 @@ var (
 	errInsufficientPermissions       = errors.New("insufficient permissions for performing the operation")
 	errShardingIsNotSupported        = errors.New("sharding is not supported")
 	errInsufficientShardsNumber      = errors.New("shards number should be greater than 0")
-	errInsufficientCfgSrvNumber      = errors.New("sharding: minimum config servers number is 3")
+	errInsufficientCfgSrvNumber      = errors.New("sharding: minimum config servers number is 1")
 	errEvenServersNumber             = errors.New("sharding: config servers number should be odd")
 	errDisableShardingNotSupported   = errors.New("sharding: disable sharding is not supported")
 	errChangeShardsNumNotSupported   = errors.New("sharding: change shards number is not supported")

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -1438,7 +1438,7 @@ func TestValidateSharding(t *testing.T) {
 		},
 		{
 			desc:     "insufficient configservers",
-			updated:  []byte(`{"spec": {"engine": {"type": "psmdb"}, "sharding": {"enabled": true, "shards": 1,"configServer": {"replicas": 1}}}}`),
+			updated:  []byte(`{"spec": {"engine": {"type": "psmdb"}, "sharding": {"enabled": true, "shards": 1,"configServer": {"replicas": 0}}}}`),
 			expected: errInsufficientCfgSrvNumber,
 		},
 		{


### PR DESCRIPTION
EVEREST-1404 

Minimal possible number of configservers is set to 1.  