### PR TITLE
EVEREST-107 patch sub to add VS dev url

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -336,6 +336,16 @@ jobs:
         run: |
           kubectl -n everest-system patch deployment percona-everest --type strategic --patch-file dev/patch-deployment-image.yaml
           kubectl -n everest-system rollout status deploy/percona-everest --timeout=120s
+          kubectl patch sub everest-operator -n everest-system -p '
+            [{
+                "op": "add",
+                "path": "/spec/config/env/-",
+                "value": {
+                  "name": "PERCONA_VERSION_SERVICE_URL",
+                  "value": "https://check-dev.percona.com/versions/v1"
+                }
+            }]' --type=json
+
 
       - name: Expose Everest API Server
         run: |
@@ -434,6 +444,15 @@ jobs:
         run: |
           make init
           make install-operators
+          kubectl patch sub everest-operator -n everest-system -p '
+            [{
+                "op": "add",
+                "path": "/spec/config/env/-",
+                "value": {
+                  "name": "PERCONA_VERSION_SERVICE_URL",
+                  "value": "https://check-dev.percona.com/versions/v1"
+                }
+            }]' --type=json
           make test-cli
       - name: Attach the report
         if: ${{ always() && steps.cli-tests.outcome != 'skipped' }}

--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -75,6 +75,16 @@ jobs:
           --operator.xtradb-cluster \
           --skip-wizard \
           --namespaces everest-ui
+          
+          kubectl patch sub everest-operator -n everest-system -p '
+            [{
+                "op": "add",
+                "path": "/spec/config/env/-",
+                "value": {
+                  "name": "PERCONA_VERSION_SERVICE_URL",
+                  "value": "https://check-dev.percona.com/versions/v1"
+                }
+            }]' --type=json
 
       - name: Adding psmdb namespace
         shell: bash

--- a/api-tests/tests/database-engines.spec.ts
+++ b/api-tests/tests/database-engines.spec.ts
@@ -42,10 +42,10 @@ test('get/edit database engine versions', async ({ request }) => {
   const engineData = await engineResponse.json()
   const availableVersions = engineData.status.availableVersions
 
-  expect(availableVersions.engine['6.0.5-4'].imageHash).toBe('b6f875974c59d8ea0174675c85f41668460233784cbf2cbe7ce5eca212ac5f6a')
-  expect(availableVersions.backup['2.3.0'].status).toBe('recommended')
+  expect(availableVersions.engine['7.0.12-7'].imageHash).toBe('7f00e19878bd143119772cd5468f1f0f9857dfcd2ae2f814d52ef3fa7cff6899')
+  expect(availableVersions.backup['2.5.0'].status).toBe('recommended')
 
-  const allowedVersions = ['6.0.5-4', '6.0.4-3', '5.0.7-6', '6.0.9-7']
+  const allowedVersions = ['6.0.5-4', '6.0.4-3', '5.0.7-6', '7.0.8-5', "7.0.12-7"]
 
   delete engineData.status
   engineData.spec.allowedVersions = allowedVersions


### PR DESCRIPTION
**Problem:** 
Using a new version of psmdb operator - `1.17.0` which is not yet at `check.percona.com` but only on `check-dev.percona.com`. The CI will fail bc the Everest operator uses the prod VS URL by default

**Solution:**
patch subscription and add the env variable `PERCONA_VERSION_SERVICE_URL` pointing to `https://check-dev.percona.com/versions/v1`