### PR TITLE
EVEREST-1428 | Filter ListDatabaseEngines API call based on RBAC

### DIFF
--- a/api/proxy.go
+++ b/api/proxy.go
@@ -79,9 +79,9 @@ func (e *EverestServer) proxyKubernetes(
 	reverseProxy.Transport = transport
 	reverseProxy.ErrorHandler = everestErrorHandler(e.l)
 	modifiers := make([]func(*http.Response) error, 0, len(respTransformers)+1)
-	modifiers = append(modifiers, everestResponseModifier(e.l))
+	modifiers = append(modifiers, everestResponseModifier(e.l)) //nolint:bodyclose
 	for _, fn := range respTransformers {
-		modifiers = append(modifiers, func(r *http.Response) error {
+		modifiers = append(modifiers, func(r *http.Response) error { //nolint:bodyclose
 			return runResponseModifier(r, e.l, fn)
 		})
 	}

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -82,7 +82,7 @@ func (e *EverestServer) proxyKubernetes(
 	modifiers = append(modifiers, everestResponseModifier(e.l))
 	for _, fn := range respTransformers {
 		modifiers = append(modifiers, func(r *http.Response) error {
-			return runResponseMofifier(r, e.l, fn)
+			return runResponseModifier(r, e.l, fn)
 		})
 	}
 	reverseProxy.ModifyResponse = func(resp *http.Response) error {
@@ -140,7 +140,7 @@ func transformK8sList(mutate func(l *unstructured.UnstructuredList) error) apiRe
 
 // Runs the provided transform func.
 // Main purpose of this helper is to provide boiler plate for reading/writing to the response object.
-func runResponseMofifier(resp *http.Response, logger *zap.SugaredLogger, transform apiResponseTransformerFn) error {
+func runResponseModifier(resp *http.Response, logger *zap.SugaredLogger, transform apiResponseTransformerFn) error {
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error(errors.Join(err, errors.New("failed to read response body")))

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -216,6 +216,9 @@ func NewEnforceHandler(basePath string, enforcer *casbin.Enforcer) func(c echo.C
 		if !ok {
 			return false, errors.New("invalid method")
 		}
+		namespace := c.Param("namespace")
+		name := c.Param("name")
+		object = namespace + "/" + name
 		// Always allowing listing all namespaces.
 		// The result is filtered based on permission.
 		if resource == ResourceNamespaces {
@@ -223,12 +226,9 @@ func NewEnforceHandler(basePath string, enforcer *casbin.Enforcer) func(c echo.C
 		}
 		// Always allow listing database engines.
 		// The result is filtered based on permission.
-		if resource == ResourceDatabaseEngines && object == "" && action == ActionRead {
+		if resource == ResourceDatabaseEngines && name == "" && action == ActionRead {
 			return true, nil
 		}
-		namespace := c.Param("namespace")
-		name := c.Param("name")
-		object = namespace + "/" + name
 		return enforcer.Enforce(user, resource, action, object)
 	}
 }


### PR DESCRIPTION
Similar to `ListNamespaces` API call, we will allow users to list db-engines, however the response itself shall be filtered based on the RBAC policy.