### PR TITLE
EVEREST-1433-restore-permissions: change create to createRestore permission

### DIFF
--- a/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list-menu-actions.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list-menu-actions.tsx
@@ -37,18 +37,16 @@ export const BackupActionButtons = (
     namespace: dbCluster.metadata.namespace,
   });
 
-  const { canUpdate: canUpdateDb } = useGetPermissions({
-    resource: 'database-clusters',
-    specificResource: dbCluster.metadata.name,
-    namespace: dbCluster.metadata.namespace,
-  });
-
   const { canCreate: canCreateDb } = useGetPermissions({
     resource: 'database-clusters',
   });
+  const { canCreate: canCreateRestore } = useGetPermissions({
+    resource: 'database-cluster-restores',
+    namespace: dbCluster.metadata.namespace,
+  });
 
   return [
-    ...(canUpdateDb
+    ...(canCreateRestore
       ? [
           <MenuItem
             key={0}

--- a/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list-menu-actions.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list-menu-actions.tsx
@@ -37,9 +37,6 @@ export const BackupActionButtons = (
     namespace: dbCluster.metadata.namespace,
   });
 
-  const { canCreate: canCreateDb } = useGetPermissions({
-    resource: 'database-clusters',
-  });
   const { canCreate: canCreateRestore } = useGetPermissions({
     resource: 'database-cluster-restores',
     namespace: dbCluster.metadata.namespace,
@@ -66,7 +63,7 @@ export const BackupActionButtons = (
           </MenuItem>,
         ]
       : []),
-    ...(canCreateDb
+    ...(canCreateRestore
       ? [
           <MenuItem
             key={1}

--- a/ui/apps/everest/src/pages/db-cluster-details/db-action-button.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/db-action-button.tsx
@@ -20,9 +20,7 @@ import { DbCluster, DbClusterStatus } from 'shared-types/dbCluster.types';
 import { CustomConfirmDialog } from 'components/custom-confirm-dialog';
 import { useDbBackups } from 'hooks/api/backups/useBackups';
 import { DbEngineType } from '@percona/types';
-import {
-  useGetPermissions,
-} from 'utils/useGetPermissions';
+import { useGetPermissions } from 'utils/useGetPermissions';
 import DbStatusDetailsDialog from 'modals/db-status-details-dialog/db-status-details-dialog';
 
 export const DbActionButton = ({

--- a/ui/apps/everest/src/pages/db-cluster-details/db-action-button.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/db-action-button.tsx
@@ -22,7 +22,6 @@ import { useDbBackups } from 'hooks/api/backups/useBackups';
 import { DbEngineType } from '@percona/types';
 import {
   useGetPermissions,
-  useGetPermittedNamespaces,
 } from 'utils/useGetPermissions';
 import DbStatusDetailsDialog from 'modals/db-status-details-dialog/db-status-details-dialog';
 
@@ -71,10 +70,6 @@ export const DbActionButton = ({
   const disableKeepDataCheckbox =
     dbCluster?.spec.engine.type === DbEngineType.POSTGRESQL;
   const hideCheckbox = !backups.length;
-
-  const { canCreate } = useGetPermittedNamespaces({
-    resource: 'database-clusters',
-  });
 
   const { canCreate: canCreateRestore } = useGetPermissions({
     resource: 'database-cluster-restores',
@@ -137,7 +132,7 @@ export const DbActionButton = ({
               <RestartAltIcon /> {Messages.menuItems.restart}
             </MenuItem>
           )}
-          {canCreate && (
+          {canCreateRestore && (
             <MenuItem
               data-testid={`${dbClusterName}-create-new-db-from-backup`}
               disabled={restoring}


### PR DESCRIPTION
after fix:
create Restore to new DB  is no longer available if permission canCreateRestore is missing (actions menu + row actions button)
(restore to new DB was fixed in EVEREST-1408)
![image](https://github.com/user-attachments/assets/e3118b40-83f5-4f34-bb8c-c8c9e3929028)
