### PR TITLE
EVEREST-1449-blinking-of-create-backup-btn

### DIFF
--- a/ui/apps/everest/src/utils/useGetPermissions.ts
+++ b/ui/apps/everest/src/utils/useGetPermissions.ts
@@ -74,11 +74,7 @@ export const useGetPermissions = ({
       }));
     });
 
-    authorize(
-      'create',
-      resource,
-      namespaces.map((n) => `${n}/*`)
-    ).then((permitted) => {
+    authorize('create', resource, `${namespace}/*`).then((permitted) => {
       setPermissions((oldPermissions) => ({
         ...oldPermissions,
         canCreate: permitted,


### PR DESCRIPTION
Before: blinking create backup button in the right top corner (the eleventh second of the video)
https://github.com/user-attachments/assets/14917259-7642-4eb0-8c88-7a8ae37c4b03

After: no blinking
https://github.com/user-attachments/assets/e1baf203-fa30-450b-a3e7-95a543a8c8ca

policies duting reproducion
![image](https://github.com/user-attachments/assets/5c6acb23-90e8-4518-ab92-de1a345d82f3)

+fix of displaying create backups button (depending on namespaces)
![image](https://github.com/user-attachments/assets/4c95f1a4-0b01-4d72-98f8-9178c720d429)

