### PR TITLE
EVEREST-1461 - Change test MinIO from Pod to Deployment

### DIFF
--- a/.github/minio.conf.yaml
+++ b/.github/minio.conf.yaml
@@ -17,45 +17,54 @@ spec:
     requests:
       storage: 5Gi
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: minio
   name: minio
   namespace: minio
 spec:
-  containers:
-    - name: minio
-      image: quay.io/minio/minio:latest
-      command:
-        - /bin/bash
-        - -c
-      args:
-        - minio server /data --console-address :9090
-      volumeMounts:
-        - mountPath: /data
-          name: minio-data-vol
-        - mountPath: /root/.minio/certs
-          name: minio-cert
-  initContainers:
-    - name: init-minio
-      image: busybox
-      command:
-        - /bin/sh
-        - -c
-      args:
-        - mkdir -p /data/bucket-1 /data/bucket-2 /data/bucket-3 /data/bucket-4
-      volumeMounts:
-        - mountPath: /data
-          name: minio-data-vol
-  volumes:
-    - name: minio-data-vol
-      persistentVolumeClaim:
-        claimName: minio-data
-    - name: minio-cert
-      secret:
-        secretName: minio-cert
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:latest
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - minio server /data --console-address :9090
+          volumeMounts:
+            - mountPath: /data
+              name: minio-data-vol
+            - mountPath: /root/.minio/certs
+              name: minio-cert
+      initContainers:
+        - name: init-minio
+          image: busybox
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - mkdir -p /data/bucket-1 /data/bucket-2 /data/bucket-3 /data/bucket-4
+          volumeMounts:
+            - mountPath: /data
+              name: minio-data-vol
+      volumes:
+        - name: minio-data-vol
+          persistentVolumeClaim:
+            claimName: minio-data
+        - name: minio-cert
+          secret:
+            secretName: minio-cert
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Minio which is used for UI E2E tests is executed as a Pod kind which often fails and the Pod will not be restarted and the tests fail (often seen when executing locally), so it is better to use a Deployment kind which will restart the Pod if it faces some issues.