### PR TITLE
EVEREST-1467 - Add option to select database and size for UI E2E test

### DIFF
--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -97,14 +97,7 @@ test.describe.configure({ retries: 0 });
           namespace,
           token
         );
-        for (let i = 0; i < monitoringInstances.length; i++) {
-          await deleteMonitoringInstance(
-            request,
-            namespace,
-            monitoringInstances[i].name,
-            token
-          );
-        }
+        for (const instance of monitoringInstances) { await deleteMonitoringInstance(request, namespace, instance.name, token); }
       });
 
       test(`Cluster creation with ${db} and size ${size}`, async ({

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -36,10 +36,19 @@ import {
   findRowAndClickActions,
 } from '../utils/table';
 import { checkError } from '../utils/generic';
-import { deleteMonitoringInstance, listMonitoringInstances } from '../utils/monitoring-instance';
+import {
+  deleteMonitoringInstance,
+  listMonitoringInstances,
+} from '../utils/monitoring-instance';
 import { clickOnDemandBackup } from '../db-cluster-details/utils';
 
-const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD, SELECT_DB, SELECT_SIZE } = process.env;
+const {
+  MONITORING_URL,
+  MONITORING_USER,
+  MONITORING_PASSWORD,
+  SELECT_DB,
+  SELECT_SIZE,
+} = process.env;
 let token: string;
 
 test.describe.configure({ retries: 0 });
@@ -56,7 +65,11 @@ test.describe.configure({ retries: 0 });
       tag: '@release',
     },
     () => {
-      test.skip(() => (SELECT_DB !== db && !!SELECT_DB) || (SELECT_SIZE !== size.toString() && !!SELECT_SIZE));
+      test.skip(
+        () =>
+          (SELECT_DB !== db && !!SELECT_DB) ||
+          (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
+      );
       test.describe.configure({ timeout: 720000 });
 
       const clusterName = `${db}-${size}-dembkp`;
@@ -79,7 +92,11 @@ test.describe.configure({ retries: 0 });
       test.afterAll(async ({ request }) => {
         // we try to delete all monitoring instances because cluster creation expects that none exist
         // (monitoring instance is added in the form where the warning that none exist is visible)
-        let monitoringInstances = await listMonitoringInstances(request, namespace, token);
+        let monitoringInstances = await listMonitoringInstances(
+          request,
+          namespace,
+          token
+        );
         for (let i = 0; i < monitoringInstances.length; i++) {
           await deleteMonitoringInstance(
             request,

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -36,10 +36,10 @@ import {
   findRowAndClickActions,
 } from '../utils/table';
 import { checkError } from '../utils/generic';
-import { deleteMonitoringInstance } from '../utils/monitoring-instance';
+import { deleteMonitoringInstance, listMonitoringInstances } from '../utils/monitoring-instance';
 import { clickOnDemandBackup } from '../db-cluster-details/utils';
 
-const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD } = process.env;
+const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD, SELECT_DB, SELECT_SIZE } = process.env;
 let token: string;
 
 test.describe.configure({ retries: 0 });
@@ -56,6 +56,7 @@ test.describe.configure({ retries: 0 });
       tag: '@release',
     },
     () => {
+      test.skip(() => (SELECT_DB !== db && !!SELECT_DB) || (SELECT_SIZE !== size.toString() && !!SELECT_SIZE));
       test.describe.configure({ timeout: 720000 });
 
       const clusterName = `${db}-${size}-dembkp`;
@@ -76,12 +77,17 @@ test.describe.configure({ retries: 0 });
       });
 
       test.afterAll(async ({ request }) => {
-        await deleteMonitoringInstance(
-          request,
-          namespace,
-          monitoringName,
-          token
-        );
+        // we try to delete all monitoring instances because cluster creation expects that none exist
+        // (monitoring instance is added in the form where the warning that none exist is visible)
+        let monitoringInstances = await listMonitoringInstances(request, namespace, token);
+        for (let i = 0; i < monitoringInstances.length; i++) {
+          await deleteMonitoringInstance(
+            request,
+            namespace,
+            monitoringInstances[i].name,
+            token
+          );
+        }
       });
 
       test(`Cluster creation with ${db} and size ${size}`, async ({

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -97,7 +97,14 @@ test.describe.configure({ retries: 0 });
           namespace,
           token
         );
-        for (const instance of monitoringInstances) { await deleteMonitoringInstance(request, namespace, instance.name, token); }
+        for (const instance of monitoringInstances) {
+          await deleteMonitoringInstance(
+            request,
+            namespace,
+            instance.name,
+            token
+          );
+        }
       });
 
       test(`Cluster creation with ${db} and size ${size}`, async ({

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -33,9 +33,18 @@ import {
 import { EVEREST_CI_NAMESPACES } from '../constants';
 import { waitForStatus, waitForDelete } from '../utils/table';
 import { checkError } from '../utils/generic';
-import { deleteMonitoringInstance, listMonitoringInstances } from '../utils/monitoring-instance';
+import {
+  deleteMonitoringInstance,
+  listMonitoringInstances,
+} from '../utils/monitoring-instance';
 
-const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD, SELECT_DB, SELECT_SIZE } = process.env;
+const {
+  MONITORING_URL,
+  MONITORING_USER,
+  MONITORING_PASSWORD,
+  SELECT_DB,
+  SELECT_SIZE,
+} = process.env;
 let token: string;
 
 test.describe.configure({ retries: 0 });
@@ -55,7 +64,11 @@ test.describe.configure({ retries: 0 });
       tag: '@release',
     },
     () => {
-      test.skip(() => (SELECT_DB !== db && !!SELECT_DB) || (SELECT_SIZE !== size.toString() && !!SELECT_SIZE));
+      test.skip(
+        () =>
+          (SELECT_DB !== db && !!SELECT_DB) ||
+          (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
+      );
       test.describe.configure({ timeout: 720000 });
 
       const clusterName = `${db}-${size}-deploy`;
@@ -77,7 +90,11 @@ test.describe.configure({ retries: 0 });
       test.afterAll(async ({ request }) => {
         // we try to delete all monitoring instances because cluster creation expects that none exist
         // (monitoring instance is added in the form where the warning that none exist is visible)
-        let monitoringInstances = await listMonitoringInstances(request, namespace, token);
+        let monitoringInstances = await listMonitoringInstances(
+          request,
+          namespace,
+          token
+        );
         for (let i = 0; i < monitoringInstances.length; i++) {
           await deleteMonitoringInstance(
             request,

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -95,14 +95,7 @@ test.describe.configure({ retries: 0 });
           namespace,
           token
         );
-        for (let i = 0; i < monitoringInstances.length; i++) {
-          await deleteMonitoringInstance(
-            request,
-            namespace,
-            monitoringInstances[i].name,
-            token
-          );
-        }
+        for (const instance of monitoringInstances) { await deleteMonitoringInstance(request, namespace, instance.name, token); }
       });
 
       test(`Cluster creation with ${db} and size ${size}`, async ({

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -95,7 +95,14 @@ test.describe.configure({ retries: 0 });
           namespace,
           token
         );
-        for (const instance of monitoringInstances) { await deleteMonitoringInstance(request, namespace, instance.name, token); }
+        for (const instance of monitoringInstances) {
+          await deleteMonitoringInstance(
+            request,
+            namespace,
+            instance.name,
+            token
+          );
+        }
       });
 
       test(`Cluster creation with ${db} and size ${size}`, async ({

--- a/ui/apps/everest/.e2e/utils/monitoring-instance.ts
+++ b/ui/apps/everest/.e2e/utils/monitoring-instance.ts
@@ -78,6 +78,6 @@ export const listMonitoringInstances = async (
   );
   expect(response.ok()).toBeTruthy();
 
-  const responseBody = await response.json()
+  const responseBody = await response.json();
   return responseBody;
 };

--- a/ui/apps/everest/.e2e/utils/monitoring-instance.ts
+++ b/ui/apps/everest/.e2e/utils/monitoring-instance.ts
@@ -62,3 +62,22 @@ export const deleteMonitoringInstance = async (
   );
   expect(response.ok()).toBeTruthy();
 };
+
+export const listMonitoringInstances = async (
+  request: APIRequestContext,
+  namespace,
+  token: string
+) => {
+  const response = await request.get(
+    `/v1/namespaces/${namespace}/monitoring-instances`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+  expect(response.ok()).toBeTruthy();
+
+  const responseBody = await response.json()
+  return responseBody;
+};


### PR DESCRIPTION
With this change we can select if we want to run a test for just single database or single size.
If we have a test which by default runs these combinations:
- psmdb - 1
- psmdb - 3
- pxc - 1
- pxc - 3
- pg - 1
- pg - 3

then by exporting SELECT_DB or SELECT_SIZE we can effectively filter for which db, size or both we want to run one or more tests.
This parameters will be added to the jenkins pipeline in case we want to do selective re-runs.