### PR TITLE
EVEREST-1353 improve s3 validation

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -249,6 +249,13 @@ func s3Access(
 		return errors.New("could not read from S3 bucket")
 	}
 
+	_, err = svc.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return errors.New("could not list objects in S3 bucket")
+	}
+
 	_, err = svc.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(testKey),


### PR DESCRIPTION
EVEREST-1353 

Everest operator [lists objects in s3](https://github.com/percona/everest-operator/blob/e44c8cd8a71de9a1e52b94c8165a989b333f429f/controllers/databaseclusterbackup_controller.go#L780) to figure out the PG backup destination, but when adding a new backup storage, the Everest API doesn't check if there is a permission to list objects. 

**Related PRs:**
- https://github.com/percona/everest-operator/pull/523 
  