### PR TITLE
EVEREST-1477 | [RBAC] Enforce backup-storage and monitoring-instances permission for database-clusters

### DIFF
--- a/api/monitoring_instance.go
+++ b/api/monitoring_instance.go
@@ -29,6 +29,7 @@ import (
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 	"github.com/percona/everest/pkg/pmm"
+	"github.com/percona/everest/pkg/rbac"
 )
 
 const (
@@ -321,4 +322,15 @@ func (e *EverestServer) monitoringConfigSecretData(apiKey string) map[string]str
 		"apiKey":   apiKey,
 		"username": "api_key",
 	}
+}
+
+func (e *EverestServer) canGetMonitoringConfig(user, namespace, name string) (bool, error) {
+	ok, err := e.rbacEnforcer.Enforce(
+		user, rbac.ResourceMonitoringInstances,
+		rbac.ActionRead, fmt.Sprintf("%s/%s", namespace, name),
+	)
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
 }

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -51,6 +51,7 @@ const (
 	ResourceDatabaseClusterBackups  = "database-cluster-backups"
 	ResourceDatabaseClusterRestores = "database-cluster-restores"
 	ResourceDatabaseEngines         = "database-engines"
+	ResourceMonitoringInstances     = "monitoring-instances"
 	ResourceNamespaces              = "namespaces"
 )
 


### PR DESCRIPTION
Since database-clusters contain information about backup-storages and monitoring-instances, we need to check if the user has permission for those specified resources.