### PR TITLE
EVEREST-1469 | [RBAC] Fix broken matcher function

### DIFF
--- a/data/rbac/model.conf
+++ b/data/rbac/model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && objectMatch(r.obj, p.obj)
+m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && globMatch(r.obj, p.obj)

--- a/data/rbac/model.conf
+++ b/data/rbac/model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && customKeyMatch(r.obj, p.obj)
+m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && objectMatch(r.obj, p.obj)

--- a/data/rbac/model.conf
+++ b/data/rbac/model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && customGlobMatch(r.obj, p.obj)
+m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && customKeyMatch(r.obj, p.obj)

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -115,9 +115,9 @@ func newEnforcer(adapter persist.Adapter, enableLogs bool) (*casbin.Enforcer, er
 		return nil, err
 	}
 	enf.AddFunction("customKeyMatch", func(arguments ...interface{}) (interface{}, error) {
-		key1 := arguments[0].(string)
-		key2 := arguments[1].(string)
-		return bool(keyMatch(key1, key2)), nil
+		key1 := arguments[0].(string) //nolint:forcetypeassert
+		key2 := arguments[1].(string) //nolint:forcetypeassert
+		return keyMatch(key1, key2), nil
 	})
 	return enf, nil
 }
@@ -149,17 +149,14 @@ func NewEnforcer(ctx context.Context, kubeClient *kubernetes.Kubernetes, l *zap.
 // properly handled by the key matchers in the casbin library.
 //
 // For example:
-// - keyMatch("ns-1/obj-1", "*/obj-1") => true
-// - support both "*" and "*/*" as wildcard
+// - keyMatch("ns-1/obj-1", "*/obj-1") => true.
+// - support both "*" and "*/*" as wildcard.
 func keyMatch(key1, key2 string) bool {
 	key1Parts := strings.Split(key1, "/")
 	key2Parts := strings.Split(key2, "/")
 
 	if key2 == "*" {
 		return true
-	}
-	if key2 == "*/*" {
-		return len(key1Parts) == 2
 	}
 	// Handle the cases where key1 or key2 has different lengths
 	if len(key1Parts) != len(key2Parts) {

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -114,10 +114,10 @@ func newEnforcer(adapter persist.Adapter, enableLogs bool) (*casbin.Enforcer, er
 	if err := validatePolicy(enf); err != nil {
 		return nil, err
 	}
-	enf.AddFunction("customKeyMatch", func(arguments ...interface{}) (interface{}, error) {
+	enf.AddFunction("objectMatch", func(arguments ...interface{}) (interface{}, error) {
 		key1 := arguments[0].(string) //nolint:forcetypeassert
 		key2 := arguments[1].(string) //nolint:forcetypeassert
-		return keyMatch(key1, key2), nil
+		return objectMatch(key1, key2), nil
 	})
 	return enf, nil
 }
@@ -145,13 +145,13 @@ func NewEnforcer(ctx context.Context, kubeClient *kubernetes.Kubernetes, l *zap.
 	return enforcer, refreshEnforcerInBackground(ctx, kubeClient, enforcer, l)
 }
 
-// We use a custom defined keyMatch function since we have use-cases that are not
+// We use a custom defined matcher function since we have use-cases that are not
 // properly handled by the key matchers in the casbin library.
 //
 // For example:
 // - keyMatch("ns-1/obj-1", "*/obj-1") => true.
 // - support both "*" and "*/*" as wildcard.
-func keyMatch(key1, key2 string) bool {
+func objectMatch(key1, key2 string) bool {
 	key1Parts := strings.Split(key1, "/")
 	key2Parts := strings.Split(key2, "/")
 

--- a/pkg/rbac/validate_test.go
+++ b/pkg/rbac/validate_test.go
@@ -292,6 +292,7 @@ func TestCan(t *testing.T) {
 
 func TestKeyMatch(t *testing.T) {
 	assert.True(t, keyMatch("", "*"))
+	assert.True(t, keyMatch("namespace-1/object-1", "*"))
 	assert.True(t, keyMatch("/", "*/*"))
 	assert.True(t, keyMatch("namespace-1/", "namespace-1/*"))
 	assert.True(t, keyMatch("namespace-1/object-1", "namespace-1/*"))

--- a/pkg/rbac/validate_test.go
+++ b/pkg/rbac/validate_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidatePolicy(t *testing.T) {
@@ -286,4 +288,20 @@ func TestCan(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeyMatch(t *testing.T) {
+	assert.True(t, keyMatch("", "*"))
+	assert.True(t, keyMatch("/", "*/*"))
+	assert.True(t, keyMatch("namespace-1/", "namespace-1/*"))
+	assert.True(t, keyMatch("namespace-1/object-1", "namespace-1/*"))
+	assert.False(t, keyMatch("namespace-2/", "namespace-1/*"))
+	assert.False(t, keyMatch("namespace-2/object-1", "namespace-1/*"))
+	assert.True(t, keyMatch("namespace-1/", "*/*"))
+	assert.True(t, keyMatch("namespace-1/object-1", "*/*"))
+	assert.False(t, keyMatch("namespace-1/object-1", "namespace-2/object-1"))
+	assert.False(t, keyMatch("namespace-2/object-2", "namespace-2/object-1"))
+	assert.False(t, keyMatch("namespace-2/object-2", "*/object-1"))
+	assert.True(t, keyMatch("namespace-2/object-1", "*/object-1"))
+	assert.True(t, keyMatch("namespace-2", "*"))
 }

--- a/pkg/rbac/validate_test.go
+++ b/pkg/rbac/validate_test.go
@@ -290,19 +290,20 @@ func TestCan(t *testing.T) {
 	}
 }
 
-func TestKeyMatch(t *testing.T) {
-	assert.True(t, keyMatch("", "*"))
-	assert.True(t, keyMatch("namespace-1/object-1", "*"))
-	assert.True(t, keyMatch("/", "*/*"))
-	assert.True(t, keyMatch("namespace-1/", "namespace-1/*"))
-	assert.True(t, keyMatch("namespace-1/object-1", "namespace-1/*"))
-	assert.False(t, keyMatch("namespace-2/", "namespace-1/*"))
-	assert.False(t, keyMatch("namespace-2/object-1", "namespace-1/*"))
-	assert.True(t, keyMatch("namespace-1/", "*/*"))
-	assert.True(t, keyMatch("namespace-1/object-1", "*/*"))
-	assert.False(t, keyMatch("namespace-1/object-1", "namespace-2/object-1"))
-	assert.False(t, keyMatch("namespace-2/object-2", "namespace-2/object-1"))
-	assert.False(t, keyMatch("namespace-2/object-2", "*/object-1"))
-	assert.True(t, keyMatch("namespace-2/object-1", "*/object-1"))
-	assert.True(t, keyMatch("namespace-2", "*"))
+func TestObjectMatch(t *testing.T) {
+	t.Parallel()
+	assert.True(t, objectMatch("", "*"))
+	assert.True(t, objectMatch("namespace-1/object-1", "*"))
+	assert.True(t, objectMatch("/", "*/*"))
+	assert.True(t, objectMatch("namespace-1/", "namespace-1/*"))
+	assert.True(t, objectMatch("namespace-1/object-1", "namespace-1/*"))
+	assert.False(t, objectMatch("namespace-2/", "namespace-1/*"))
+	assert.False(t, objectMatch("namespace-2/object-1", "namespace-1/*"))
+	assert.True(t, objectMatch("namespace-1/", "*/*"))
+	assert.True(t, objectMatch("namespace-1/object-1", "*/*"))
+	assert.False(t, objectMatch("namespace-1/object-1", "namespace-2/object-1"))
+	assert.False(t, objectMatch("namespace-2/object-2", "namespace-2/object-1"))
+	assert.False(t, objectMatch("namespace-2/object-2", "*/object-1"))
+	assert.True(t, objectMatch("namespace-2/object-1", "*/object-1"))
+	assert.True(t, objectMatch("namespace-2", "*"))
 }

--- a/pkg/rbac/validate_test.go
+++ b/pkg/rbac/validate_test.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidatePolicy(t *testing.T) {
@@ -288,22 +286,4 @@ func TestCan(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestObjectMatch(t *testing.T) {
-	t.Parallel()
-	assert.True(t, objectMatch("", "*"))
-	assert.True(t, objectMatch("namespace-1/object-1", "*"))
-	assert.True(t, objectMatch("/", "*/*"))
-	assert.True(t, objectMatch("namespace-1/", "namespace-1/*"))
-	assert.True(t, objectMatch("namespace-1/object-1", "namespace-1/*"))
-	assert.False(t, objectMatch("namespace-2/", "namespace-1/*"))
-	assert.False(t, objectMatch("namespace-2/object-1", "namespace-1/*"))
-	assert.True(t, objectMatch("namespace-1/", "*/*"))
-	assert.True(t, objectMatch("namespace-1/object-1", "*/*"))
-	assert.False(t, objectMatch("namespace-1/object-1", "namespace-2/object-1"))
-	assert.False(t, objectMatch("namespace-2/object-2", "namespace-2/object-1"))
-	assert.False(t, objectMatch("namespace-2/object-2", "*/object-1"))
-	assert.True(t, objectMatch("namespace-2/object-1", "*/object-1"))
-	assert.True(t, objectMatch("namespace-2", "*"))
 }

--- a/ui/apps/everest/public/static/model.conf
+++ b/ui/apps/everest/public/static/model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && keyMatch(r.obj, p.obj)
+m = g(r.sub, p.sub) && globMatch(r.res, p.res) && globMatch(r.act, p.act) && globMatch(r.obj, p.obj)


### PR DESCRIPTION
### Problem

We added a custom globMatch function in https://github.com/percona/everest/pull/665 to satisfy the use case of being able to define  objects in the format`*/<resource-1>`, however, it broke the namespaces permission.

### Solution

It looks like we do not really need a custom globMatch afterall, and our use-case can be handled well by the default `globMatch`. The reason for adding a custom function earlier was so that it could also satisfy a wildcard in the request (for example, in the `can` command), however, we never get a wildcard from the request side, except for the `can` command, so we can explicitly handle it there instead of adding any custom logic in the key matcher.

I'm also not really sure how the broken matcher got through, since it worked fine during the local testing, and also did not CI errors.