### PR TITLE
EVEREST-1305 fix minimun config server replicas for sharded clusters

### DIFF
--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -1468,8 +1468,13 @@ func TestValidateSharding(t *testing.T) {
 		},
 		{
 			desc:     "insufficient configservers",
-			cluster:  []byte(`{"spec": {"engine": {"type": "psmdb", "version": "1.17.0"}, "sharding": {"enabled": true, "shards": 1,"configServer": {"replicas": 0}}}}`),
+			cluster:  []byte(`{"spec": {"engine": {"type": "psmdb", "version": "1.17.0", "replicas": 3}, "sharding": {"enabled": true, "shards": 1,"configServer": {"replicas": 1}}}}`),
 			expected: errInsufficientCfgSrvNumber,
+		},
+		{
+			desc:     "insufficient configservers 1 node",
+			cluster:  []byte(`{"spec": {"engine": {"type": "psmdb", "version": "1.17.0", "replicas": 1}, "sharding": {"enabled": true, "shards": 1,"configServer": {"replicas": 0}}}}`),
+			expected: errInsufficientCfgSrvNumber1Node,
 		},
 		{
 			desc:     "insufficient shards number",


### PR DESCRIPTION
[EVEREST-1305](https://perconadev.atlassian.net/browse/EVEREST-1305)
Unless we are running a 1-node replset the minimum number of config servers is 3.

[EVEREST-1305]: https://perconadev.atlassian.net/browse/EVEREST-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ