### PR TITLE
EVEREST-1562 | Add --dry-run flag to upgrade cmd

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -70,7 +70,7 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 func initUpgradeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("version-metadata-url", "https://check.percona.com", "URL to retrieve version metadata information from")
 	cmd.Flags().BoolP("logs", "l", false, "If set, logs are printed during the upgrade process")
-	cmd.Flags().Bool("dry-run", false, "If set, simulate the upgrade process")
+	cmd.Flags().Bool("dry-run", false, "If set, only executes the pre-upgrade checks")
 }
 
 func initUpgradeViperFlags(cmd *cobra.Command) {

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -70,6 +70,7 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 func initUpgradeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("version-metadata-url", "https://check.percona.com", "URL to retrieve version metadata information from")
 	cmd.Flags().BoolP("logs", "l", false, "If set, logs are printed during the upgrade process")
+	cmd.Flags().Bool("dry-run", false, "If set, simulate the upgrade process")
 }
 
 func initUpgradeViperFlags(cmd *cobra.Command) {
@@ -78,6 +79,7 @@ func initUpgradeViperFlags(cmd *cobra.Command) {
 	viper.BindPFlag("version-metadata-url", cmd.Flags().Lookup("version-metadata-url")) //nolint:errcheck,gosec
 	viper.BindPFlag("verbose", cmd.Flags().Lookup("verbose"))                           //nolint:errcheck,gosec
 	viper.BindPFlag("json", cmd.Flags().Lookup("json"))                                 //nolint:errcheck,gosec
+	viper.BindPFlag("dry-run", cmd.Flags().Lookup("dry-run"))                           //nolint:errcheck,gosec
 }
 
 func parseUpgradeConfig() (*upgrade.Config, error) {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -87,6 +87,8 @@ type (
 		KubeconfigPath string `mapstructure:"kubeconfig"`
 		// VersionMetadataURL stores hostname to retrieve version metadata information from.
 		VersionMetadataURL string `mapstructure:"version-metadata-url"`
+		// DryRun is set to simulate the upgrade process.
+		DryRun bool `mapstructure:"dry-run"`
 		// If set, we will print the pretty output.
 		Pretty bool
 	}
@@ -98,6 +100,7 @@ type (
 		config         *Config
 		kubeClient     kubernetes.KubernetesConnector
 		versionService versionservice.Interface
+		dryRun         bool
 	}
 
 	requirementsCheck struct {
@@ -128,6 +131,7 @@ func NewUpgrade(cfg *Config, l *zap.SugaredLogger) (*Upgrade, error) {
 		}
 		return nil, err
 	}
+	cli.dryRun = cfg.DryRun
 	cli.kubeClient = k
 	cli.versionService = versionservice.New(cfg.VersionMetadataURL)
 	return cli, nil
@@ -157,6 +161,10 @@ func (u *Upgrade) Run(ctx context.Context) error {
 			return nil
 		}
 		return err
+	}
+
+	if u.dryRun {
+		return nil
 	}
 
 	upgradeSteps := []common.Step{}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -87,7 +87,7 @@ type (
 		KubeconfigPath string `mapstructure:"kubeconfig"`
 		// VersionMetadataURL stores hostname to retrieve version metadata information from.
 		VersionMetadataURL string `mapstructure:"version-metadata-url"`
-		// DryRun is set to simulate the upgrade process.
+		// DryRun is set if the upgrade process should only perform pre-upgrade checks and not perform the actual upgrade.
 		DryRun bool `mapstructure:"dry-run"`
 		// If set, we will print the pretty output.
 		Pretty bool


### PR DESCRIPTION
Setting the `--dry-run` flag to the upgrade command will only run the pre-requisite checks, and not perform the actual upgrade.