### PR TITLE
EVEREST-1561 fix nil dereference in PITR

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -429,6 +429,9 @@ func (e *EverestServer) GetDatabaseClusterPitr(ctx echo.Context, namespace, name
 	}
 
 	latestBackup := latestSuccessfulBackup(backups.Items)
+	if latestBackup == nil || latestBackup.Status.CreatedAt == nil {
+		return ctx.JSON(http.StatusOK, response)
+	}
 
 	backupTime := latestBackup.Status.CreatedAt.UTC()
 	var latest *time.Time


### PR DESCRIPTION
EVEREST-1561

Nil dereference error appeared bc the code assumed that if there are any backups, at least one of them should be succeeded and have the creation date, which is not correct. 

