### PR TITLE
EVEREST-1534 | Filter the result of ListDatabaseClusters based on RBAC

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -90,6 +90,13 @@ func (e *EverestServer) CreateDatabaseCluster(ctx echo.Context, namespace string
 // enforceDBClusterRBAC checks if the user has permission to read the backup-storage and monitoring-instances associated
 // with the provided DB cluster.
 func (e *EverestServer) enforceDBClusterRBAC(user string, db *everestv1alpha1.DatabaseCluster) error {
+	// Check if the user has permissions for this DB cluster?
+	if err := e.enforce(user, rbac.ResourceDatabaseClusters, rbac.ActionRead, rbac.ObjectName(db.GetNamespace(), db.GetName())); err != nil {
+		if !errors.Is(err, errInsufficientPermissions) {
+			e.l.Error(errors.Join(err, errors.New("failed to check db-cluster permissions")))
+		}
+		return err
+	}
 	// Check if the user has permissions for all backup-storages in the schedule?
 	for _, sched := range db.Spec.Backup.Schedules {
 		bsName := sched.BackupStorageName

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -270,9 +270,13 @@ func NewEnforceHandler(l *zap.SugaredLogger, basePath string, enforcer *casbin.E
 		if resource == ResourceNamespaces {
 			return true, nil
 		}
-		// Always allow listing database engines.
-		// The result is filtered based on permission.
-		if resource == ResourceDatabaseEngines && name == "" && action == ActionRead {
+		// Listing the following objects is always allowed here,
+		// since we will filter the output of the list itself based on the permissions.
+		allowedObjectsForListing := []string{
+			ResourceDatabaseClusters,
+			ResourceDatabaseEngines,
+		}
+		if slices.Contains(allowedObjectsForListing, resource) && name == "" && action == ActionRead {
 			return true, nil
 		}
 		if ok, err := enforcer.Enforce(user, resource, action, object); err != nil {


### PR DESCRIPTION
Currently we allow the ListDatabaseClusters API call only if the user has access to all clusters. With this change, user will be able to always access this API, but the actual result itself is filtered on the basis of RBAC.