### PR TITLE
EVEREST-1583 fix stuck restores

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -440,7 +440,7 @@ func (e *EverestServer) GetDatabaseClusterPitr(ctx echo.Context, namespace, name
 		return ctx.JSON(http.StatusOK, response)
 	}
 
-	backupTime := latestBackup.Status.CreatedAt.UTC()
+	backupTime := latestBackup.Status.CompletedAt.UTC()
 	var latest *time.Time
 	// if there is the LatestRestorableTime set in the CR, use it
 	// except of psmdb which has a bug https://perconadev.atlassian.net/browse/K8SPSMDB-1186


### PR DESCRIPTION
EVEREST-1583

Everest was using the `CreatedAt` filed of the latest backup to calculate heuristics for the latest restorable time. Using `CompletedAt` makes more sense, because backups themselves take some time. 

--------
  _Details:_
There is a failure case when a backup took some time (~3min) and the restore was made shortly after the first pitr option got available, so it caused the restore targeted the time _between_ `CreatedAt` and `CompletedAt` of the latest backup which caused the restore failed with 
```
snapshot's last write is later than the target time. Try to set an earlier snapshot. Or leave the snapshot empty so PBM will choose one.
```

