### PR TITLE
Fix: restore modal form validation

### DIFF
--- a/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal-schema.ts
+++ b/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal-schema.ts
@@ -36,12 +36,18 @@ export const schema = (gaps: boolean, minDate?: Date, maxDate?: Date) =>
               code: z.ZodIssueCode.invalid_date,
             });
           }
+        } else {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+          });
         }
+
         if (gaps) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
           });
         }
+
         if (!pitrBackup) {
           ctx.addIssue({
             code: z.ZodIssueCode.invalid_date,

--- a/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal-schema.ts
+++ b/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal-schema.ts
@@ -1,3 +1,4 @@
+import { isAfter, isBefore, isDate } from 'date-fns';
 import { z } from 'zod';
 
 export enum RestoreDbFields {
@@ -11,16 +12,12 @@ export enum BackuptypeValues {
   fromPitr = 'fromPITR',
 }
 
-export const schema = (minDate: Date, maxDate: Date, gaps: boolean) =>
+export const schema = (gaps: boolean, minDate?: Date, maxDate?: Date) =>
   z
     .object({
       [RestoreDbFields.backupType]: z.nativeEnum(BackuptypeValues),
       [RestoreDbFields.backupName]: z.string().optional(),
-      [RestoreDbFields.pitrBackup]: z
-        .date()
-        .min(minDate)
-        .max(maxDate)
-        .optional(),
+      [RestoreDbFields.pitrBackup]: z.date().optional(),
     })
     .superRefine(({ backupType, backupName, pitrBackup }, ctx) => {
       if (backupType === BackuptypeValues.fromBackup) {
@@ -33,6 +30,13 @@ export const schema = (minDate: Date, maxDate: Date, gaps: boolean) =>
           });
         }
       } else {
+        if (isDate(minDate) && isDate(maxDate) && isDate(pitrBackup)) {
+          if (isAfter(pitrBackup, maxDate) || isBefore(pitrBackup, minDate)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.invalid_date,
+            });
+          }
+        }
         if (gaps) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal.tsx
+++ b/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal.tsx
@@ -12,7 +12,11 @@ import { FormDialog } from 'components/form-dialog';
 import { FormDialogProps } from 'components/form-dialog/form-dialog.types';
 import { DATE_FORMAT, PITR_DATE_FORMAT } from 'consts';
 import { format } from 'date-fns';
-import { useDbBackups, useDbClusterPitr } from 'hooks/api/backups/useBackups';
+import {
+  BACKUPS_QUERY_KEY,
+  useDbBackups,
+  useDbClusterPitr,
+} from 'hooks/api/backups/useBackups';
 import {
   useDbClusterRestoreFromBackup,
   useDbClusterRestoreFromPointInTime,
@@ -211,9 +215,18 @@ const RestoreDbModal = <T extends FieldValues>({
   backupName?: string;
 }) => {
   const navigate = useNavigate();
+  // we use a different query key for the restore modal to avoid re-renders from "useDbBackups" running in the background
   const { data: backups = [], isLoading } = useDbBackups(
     dbCluster.metadata.name,
-    namespace
+    namespace,
+    {
+      queryKey: [
+        BACKUPS_QUERY_KEY,
+        namespace,
+        dbCluster.metadata.name,
+        'restore-modal',
+      ],
+    }
   );
   const { data: pitrData } = useDbClusterPitr(
     dbCluster.metadata.name,

--- a/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal.tsx
+++ b/ui/apps/everest/src/modals/restore-db-modal/restore-db-modal.tsx
@@ -237,9 +237,9 @@ const RestoreDbModal = <T extends FieldValues>({
         isNewClusterMode ? Messages.headerMessageCreate : Messages.headerMessage
       }
       schema={schema(
-        pitrData?.earliestDate || new Date(),
-        pitrData?.latestDate || new Date(),
-        !!pitrData?.gaps
+        !!pitrData?.gaps,
+        pitrData?.earliestDate,
+        pitrData?.latestDate
       )}
       submitting={restoringFromBackup || restoringFromPointInTime}
       defaultValues={{ ...defaultValues, backupName: backupName || '' }}

--- a/ui/apps/everest/src/shared-types/query.types.ts
+++ b/ui/apps/everest/src/shared-types/query.types.ts
@@ -1,8 +1,12 @@
 import { DefaultError, QueryKey, UseQueryOptions } from '@tanstack/react-query';
 
+// These shenanigans allow us to have 'queryKey' as optional on queryOptions
 export type PerconaQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
-> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey'>;
+> = Partial<
+  Pick<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey'>
+> &
+  Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey'>;


### PR DESCRIPTION
Our restore modal was doing improper form validation, disabling the button even when a backup name was selected.
Improved the validation logic and render flows.