### PR TITLE
EVEREST-1635 - Remove custom global timeout in UI tests

### DIFF
--- a/ui/apps/everest/.e2e/playwright.config.ts
+++ b/ui/apps/everest/.e2e/playwright.config.ts
@@ -44,7 +44,6 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: 1,
-  timeout: TIMEOUTS.TwentyMinutes,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['github'],


### PR DESCRIPTION
This needs to be removed because some assertions then wait for 12 minutes to fail which is too much.
As I can see we still have in each test group `test.describe.configure({ timeout: 720000 });` so we will try with this - if this is also going to lead to similar problems we will add something like `test.setTimeout(size * 120000);` with appropriate value into each test.