### PR TITLE
Update EVEREST_BUCKETS_NAMESPACES_MAP in dev-fe-e2e.yaml

### DIFF
--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -149,7 +149,7 @@ jobs:
       - name: Run integration tests
         shell: bash
         env:
-          EVEREST_BUCKETS_NAMESPACES_MAP: '[["bucket-1","everest-ui"],["bucket-2","psmdb-only"],["bucket-3","pxc-only"],["bucket-4","pg-only"]]'
+          EVEREST_BUCKETS_NAMESPACES_MAP: '[["bucket-1","everest-ui"],["bucket-2","psmdb-only"],["bucket-3","pxc-only"],["bucket-4","pg-only"],["bucket-5","everest-ui"]]'
           EVEREST_LOCATION_ACCESS_KEY: "minioadmin"
           EVEREST_LOCATION_SECRET_KEY: "minioadmin"
           EVEREST_LOCATION_REGION: "us-east-1"

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -70,7 +70,7 @@ test.describe.configure({ retries: 0 });
           (SELECT_DB !== db && !!SELECT_DB) ||
           (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
       );
-      test.describe.configure({ timeout: 720000 });
+      test.describe.configure({ timeout: 900000 });
 
       const clusterName = `${db}-${size}-dembkp`;
 

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -68,7 +68,7 @@ test.describe.configure({ retries: 0 });
           (SELECT_DB !== db && !!SELECT_DB) ||
           (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
       );
-      test.describe.configure({ timeout: 720000 });
+      test.describe.configure({ timeout: 900000 });
 
       const clusterName = `${db}-${size}-deploy`;
 
@@ -169,7 +169,7 @@ test.describe.configure({ retries: 0 });
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
           await waitForStatus(page, clusterName, 'Initializing', 15000);
-          await waitForStatus(page, clusterName, 'Up', 360000);
+          await waitForStatus(page, clusterName, 'Up', 600000);
         });
 
         await test.step('Check db cluster k8s object options', async () => {

--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -126,7 +126,7 @@ test.describe.configure({ retries: 0 });
           (SELECT_DB !== db && !!SELECT_DB) ||
           (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
       );
-      test.describe.configure({ timeout: 720000 });
+      test.describe.configure({ timeout: 900000 });
 
       const clusterName = `${db}-${size}-pitr`;
 
@@ -249,7 +249,7 @@ test.describe.configure({ retries: 0 });
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
           await waitForStatus(page, clusterName, 'Initializing', 15000);
-          await waitForStatus(page, clusterName, 'Up', 660000);
+          await waitForStatus(page, clusterName, 'Up', 600000);
         });
 
         await test.step('Update PSMDB cluster PITR uploadIntervalSec', async () => {

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -81,7 +81,7 @@ function getNextScheduleMinute(incrementMinutes: number): string {
           (SELECT_DB !== db && !!SELECT_DB) ||
           (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
       );
-      test.describe.configure({ timeout: 720000 });
+      test.describe.configure({ timeout: 900000 });
 
       const clusterName = `${db}-${size}-schbkp`;
 


### PR DESCRIPTION
Needed for PG in scheduled-backup.e2e.ts (second schedule).

This change it to make the environment variables the same between `pr` and `release` tests so that there won't be any conflicts down the road.

PG cannot have two schedules on the same storage, so we need to add another storage in the same namespace since we want to have two schedules for the test.

