### PR TITLE
EVEREST-866 PG PITR fallback to heuristics

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -568,10 +568,9 @@ func getDefaultUploadInterval(engine everestv1alpha1.Engine, uploadInterval *int
 		// so we still use heuristics
 		return valueOrDefault(uploadInterval, psmdbDefaultUploadInterval)
 	case everestv1alpha1.DatabaseEnginePostgresql:
-		// latest restorable time appeared in PG 2.4.0
-		if common.CheckConstraint(version, "<2.4.0") {
-			return valueOrDefault(uploadInterval, pgDefaultUploadInterval)
-		}
+		// latest restorable time appeared in PG 2.4.0, however it's not reliable https://perconadev.atlassian.net/browse/K8SPG-681
+		// so we still use heuristics
+		return valueOrDefault(uploadInterval, pgDefaultUploadInterval)
 	}
 	// for newer versions don't use the heuristics, so return 0 upload interval
 	return 0

--- a/api/database_cluster_test.go
+++ b/api/database_cluster_test.go
@@ -137,19 +137,19 @@ func TestGetDefaultUploadInterval(t *testing.T) {
 			name:     "new pg, no interval is set",
 			engine:   everestv1alpha1.Engine{Type: everestv1alpha1.DatabaseEnginePostgresql, Version: "2.4.0"},
 			interval: nil,
-			expected: 0,
+			expected: pgDefaultUploadInterval,
 		},
 		{
 			name:     "new pg, interval is set",
 			engine:   everestv1alpha1.Engine{Type: everestv1alpha1.DatabaseEnginePostgresql, Version: "2.4.0"},
 			interval: pointer.ToInt(1000),
-			expected: 0,
+			expected: 1000,
 		},
 		{
 			name:     "newer pg",
 			engine:   everestv1alpha1.Engine{Type: everestv1alpha1.DatabaseEnginePostgresql, Version: "2.4.1"},
 			interval: nil,
-			expected: 0,
+			expected: pgDefaultUploadInterval,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
**PG PITR fallback to heuristics**

Problem:

In https://github.com/percona/everest/pull/634 Everest started to use the `latestRestorableTime` field of the upstream operators. However as described in the [comment](https://perconadev.atlassian.net/browse/EVEREST-886?focusedCommentId=417659) for PG the field does not appear in some cases when it should have appeared. To address the issue, this PG operator ticket [K8SPG-681](https://perconadev.atlassian.net/browse/K8SPG-681) was created. Until the ticket is addressed it was decided to fallback to the old PG heuristics if the field is not available.  