### PR TITLE
EVEREST-107 Remove trivy

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -375,13 +375,6 @@ jobs:
           kubectl -n everest describe pods
           kubectl -n everest-system logs deploy/percona-everest
 
-#  commenting bc it's failing to download the image bc of too many requests too often
-#      - name: Everest - run Trivy vulnerability scanner
-#        uses: aquasecurity/trivy-action@0.24.0
-#        with:
-#          image-ref: "localhost:5000/perconalab/everest:0.0.0"
-#          format: 'table'
-#          severity: 'CRITICAL,HIGH'
 
 
 

--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -64,21 +64,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: "perconalab/everest:0.0.0"
-          format: "table"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
-  scan:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: "docker.io/perconalab/everest:0.0.0"
-          format: "table"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,19 +168,6 @@ jobs:
           push: false
           tags: ${{ steps.operator_meta.outputs.tags }}
 
-      - name: Operator - set everest-operator image to scan
-        id: set_operator_image
-        run: |
-          # taking the first tag to check with trivy. Since the build is the same, no need to check the rest of them
-          echo "::set-output name=image_to_check::$(echo "${{ steps.operator_meta.outputs.tags }}" | head -n 1)"
-
-      - name: Operator - run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ${{ steps.set_operator_image.outputs.image_to_check }}
-          format: "table"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
 
       - name: Operator - push everest-operator image
         uses: docker/build-push-action@v6
@@ -197,19 +184,6 @@ jobs:
           tags: ${{ steps.bundle_meta.outputs.tags }}
           file: everest-operator/bundle.Dockerfile
 
-      - name: Operator - set everest-operator-bundle image to scan
-        id: set_operator_bundle_image
-        run: |
-          # taking the first tag to check with trivy. Since the build is the same, no need to check the rest of them
-          echo "::set-output name=image_to_check::$(echo "${{ steps.bundle_meta.outputs.tags }}" | head -n 1)"
-
-      - name: Operator - Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ${{ steps.set_operator_bundle_image.outputs.image_to_check }}
-          format: "table"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
 
       - name: Operator - push everest-operator-bundle image
         uses: docker/build-push-action@v6
@@ -306,20 +280,6 @@ jobs:
           tags: ${{ steps.catalog_meta.outputs.tags }}
           file: everest-catalog/everest-catalog.Dockerfile
 
-      - name: Catalog - set catalog image to scan
-        id: set_catalog_image
-        run: |
-          # taking the first tag to check with trivy. Since the build is the same, no need to check the rest of them
-          echo "::set-output name=image_to_check::$(echo "${{ steps.catalog_meta.outputs.tags }}" | head -n 1)"
-
-      # TODO: fix the vulnerabilities in main and enable this check
-      #      - name: Catalog - run Trivy vulnerability scanner
-      #        uses: aquasecurity/trivy-action@0.24.0
-      #        with:
-      #          image-ref: ${{ steps.set_catalog_image.outputs.image_to_check }}
-      #          format: 'table'
-      #          exit-code: '1'
-      #          severity: 'CRITICAL,HIGH'
 
       - name: Catalog - push image
         uses: docker/build-push-action@v6
@@ -435,20 +395,6 @@ jobs:
           push: false
           tags: ${{ steps.everest_meta.outputs.tags }}
 
-      - name: Everest - set everest image to scan
-        id: set_everest_image
-        run: |
-          # taking the first tag to check with trivy. Since the build is the same, no need to check the rest of them
-          echo "::set-output name=image_to_check::$(echo "${{ steps.everest_meta.outputs.tags }}" | head -n 1)"
-
-      # TODO: fix the vulnerabilities in main and enable this check
-      #      - name: Everest - run Trivy vulnerability scanner
-      #        uses: aquasecurity/trivy-action@0.24.0
-      #        with:
-      #          image-ref: ${{ steps.set_everest_image.outputs.image_to_check }}
-      #          format: 'table'
-      #          exit-code: '1'
-      #          severity: 'CRITICAL,HIGH'
 
       - name: Everest - push Everest image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
EVEREST-107

At some point trivy started to fail the pipelines from time to time bc of the `TOOMANYREQUESTS` error. There are several workarounds but none of them 100% guarantee. 
Since we have Snyk which also scans for vulnerabilities, I don't think it's worth to go through all the "try and fail" path with workarounds, let's solve it ultimately - remove trivy scans from the Everest pipelines. 