### PR TITLE
EVEREST-1624 fix API tests

### DIFF
--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -40,7 +40,7 @@ test('create db cluster with monitoring config', async ({ request, page }) => {
         monitoringConfigName: monitoringConfigName1,
       },
       engine: {
-        type: 'psmdb',
+        type: 'pxc',
         replicas: 1,
         storage: {
           size: '4G',
@@ -51,7 +51,7 @@ test('create db cluster with monitoring config', async ({ request, page }) => {
         },
       },
       proxy: {
-        type: 'mongos',
+        type: 'haproxy',
         replicas: 1,
         expose: {
           type: 'internal',
@@ -106,7 +106,7 @@ test('update db cluster with a new monitoring config', async ({ request, page })
         monitoringConfigName: monitoringConfigName1,
       },
       engine: {
-        type: 'psmdb',
+        type: 'pxc',
         replicas: 1,
         storage: {
           size: '4G',
@@ -117,7 +117,7 @@ test('update db cluster with a new monitoring config', async ({ request, page })
         },
       },
       proxy: {
-        type: 'mongos',
+        type: 'haproxy',
         replicas: 1,
         expose: {
           type: 'internal',
@@ -182,7 +182,7 @@ test('update db cluster without monitoring config with a new monitoring config',
     },
     spec: {
       engine: {
-        type: 'psmdb',
+        type: 'pxc',
         replicas: 1,
         storage: {
           size: '4G',
@@ -193,7 +193,7 @@ test('update db cluster without monitoring config with a new monitoring config',
         },
       },
       proxy: {
-        type: 'mongos',
+        type: 'haproxy',
         replicas: 1,
         expose: {
           type: 'internal',
@@ -261,7 +261,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
         monitoringConfigName: monitoringConfigName1,
       },
       engine: {
-        type: 'psmdb',
+        type: 'pxc',
         replicas: 1,
         storage: {
           size: '4G',
@@ -272,7 +272,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
         },
       },
       proxy: {
-        type: 'mongos',
+        type: 'haproxy',
         replicas: 1,
         expose: {
           type: 'internal',

--- a/api-tests/tests/database-engines.spec.ts
+++ b/api-tests/tests/database-engines.spec.ts
@@ -37,10 +37,10 @@ test('get/edit database engine versions', async ({ request }) => {
   const engineData: GetDatabaseEngineResponse = await engineResponse.json();
   const availableVersions = engineData.status.availableVersions;
 
-  expect(availableVersions.engine['7.0.12-7'].imageHash).toBe('7f00e19878bd143119772cd5468f1f0f9857dfcd2ae2f814d52ef3fa7cff6899');
-  expect(availableVersions.backup['2.5.0'].status).toBe('recommended');
+  expect(availableVersions.engine['7.0.14-8'].imageHash).toBe('ed932d4e7231dcb793bf609f781226a8393aa8958b103339f4a503a8f70ed17e');
+  expect(availableVersions.backup['2.7.0'].status).toBe('recommended');
 
-  const allowedVersions = ['6.0.5-4', '6.0.4-3', '5.0.7-6', '7.0.8-5', '7.0.12-7'];
+  const allowedVersions = ['6.0.5-4', '6.0.4-3', '7.0.8-5', '7.0.12-7', '7.0.14-8'];
 
   delete engineData.status;
   engineData.spec.allowedVersions = allowedVersions;


### PR DESCRIPTION
With the upgrade to PSMDBO v1.18.0 we need to update the engine versions.
There's also an issue with 1-node replset clusters that the operator team is looking into, until that is fixed let's use PXC instead of PSMDB for the monitoring tests.