### PR TITLE
EVEREST-1680 ConnectionURL fix

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -411,24 +411,29 @@ func (e *EverestServer) connectionURL(ctx context.Context, db *everestv1alpha1.D
 	if db.Status.Hostname == "" {
 		return nil
 	}
-	url := url.URL{User: url.UserPassword(user, url.QueryEscape(password))}
+	var url string
+	defaultHost := net.JoinHostPort(db.Status.Hostname, fmt.Sprint(db.Status.Port))
 	switch db.Spec.Engine.Type {
 	case everestv1alpha1.DatabaseEnginePXC:
-		url.Scheme = "jdbc:mysql"
-		url.Host = net.JoinHostPort(db.Status.Hostname, fmt.Sprint(db.Status.Port))
+		url = queryEscapedUrl("jdbc:mysql", user, password, defaultHost)
 	case everestv1alpha1.DatabaseEnginePSMDB:
 		hosts, err := psmdbHosts(ctx, db, e.kubeClient.GetPods)
 		if err != nil {
 			e.l.Error(err)
 			return nil
 		}
-		url.Scheme = "mongodb"
-		url.Host = hosts
+		url = queryEscapedUrl("mongodb", user, password, hosts)
 	case everestv1alpha1.DatabaseEnginePostgresql:
-		url.Scheme = "postgres"
-		url.Host = net.JoinHostPort(db.Status.Hostname, fmt.Sprint(db.Status.Port))
+		url = queryEscapedUrl("postgres", user, password, defaultHost)
 	}
-	return pointer.ToString(url.String())
+	return pointer.ToString(url)
+}
+
+// Using own format instead of url.URL bc it uses the password encoding policy which does not encode char like ','
+// however such char may appear in the db passwords
+func queryEscapedUrl(scheme, user, password, hosts string) string {
+	format := "%s://%s:%s@%s"
+	return fmt.Sprintf(format, scheme, user, url.QueryEscape(password), hosts)
 }
 
 func psmdbHosts(

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -415,23 +415,23 @@ func (e *EverestServer) connectionURL(ctx context.Context, db *everestv1alpha1.D
 	defaultHost := net.JoinHostPort(db.Status.Hostname, fmt.Sprint(db.Status.Port))
 	switch db.Spec.Engine.Type {
 	case everestv1alpha1.DatabaseEnginePXC:
-		url = queryEscapedUrl("jdbc:mysql", user, password, defaultHost)
+		url = queryEscapedURL("jdbc:mysql", user, password, defaultHost)
 	case everestv1alpha1.DatabaseEnginePSMDB:
 		hosts, err := psmdbHosts(ctx, db, e.kubeClient.GetPods)
 		if err != nil {
 			e.l.Error(err)
 			return nil
 		}
-		url = queryEscapedUrl("mongodb", user, password, hosts)
+		url = queryEscapedURL("mongodb", user, password, hosts)
 	case everestv1alpha1.DatabaseEnginePostgresql:
-		url = queryEscapedUrl("postgres", user, password, defaultHost)
+		url = queryEscapedURL("postgres", user, password, defaultHost)
 	}
 	return pointer.ToString(url)
 }
 
 // Using own format instead of url.URL bc it uses the password encoding policy which does not encode char like ','
-// however such char may appear in the db passwords
-func queryEscapedUrl(scheme, user, password, hosts string) string {
+// however such char may appear in the db passwords.
+func queryEscapedURL(scheme, user, password, hosts string) string {
 	format := "%s://%s:%s@%s"
 	return fmt.Sprintf(format, scheme, user, url.QueryEscape(password), hosts)
 }

--- a/api/database_cluster_test.go
+++ b/api/database_cluster_test.go
@@ -223,7 +223,7 @@ func TestConnectionURL(t *testing.T) {
 			},
 			user:     "postgres",
 			password: "55aBDedMF;So|C?^3x|h.dDC",
-			expected: "postgres://postgres:55aBDedMF%253BSo%257CC%253F%255E3x%257Ch.dDC@postgresql-a5d-pgbouncer.everest.svc:5432",
+			expected: "postgres://postgres:55aBDedMF%3BSo%7CC%3F%5E3x%7Ch.dDC@postgresql-a5d-pgbouncer.everest.svc:5432",
 		},
 		{
 			name:    "pxc",
@@ -234,7 +234,7 @@ func TestConnectionURL(t *testing.T) {
 			},
 			user:     "root",
 			password: ",0#3PdCIc=9CS(do2",
-			expected: "jdbc:mysql://root:%252C0%25233PdCIc%253D9CS%2528do2@mysql-29o-haproxy.everest:3306",
+			expected: "jdbc:mysql://root:%2C0%233PdCIc%3D9CS%28do2@mysql-29o-haproxy.everest:3306",
 		},
 	}
 


### PR DESCRIPTION
**Problem:**
EVEREST-1680

The password in the ConnectionURL was query-escaped twice. 

**Reason:**
The used `url.URL` uses the `encodeUserPassword` policy but not the `encodeQueryComponent` which means the characters like `,` are not escaped. However such characters can still appear in the DB passwords. So I saw the characters unescaped and thought the password wasn't escaped at all that's where an extra `url.QueryEscape` came from. 

**Solution:**
Do not use `url.URL` to build the connection URL
