### PR TITLE
[UI] EVEREST-1684 Remove blue background from resources step accordion

### DIFF
--- a/ui/apps/everest/src/components/cluster-form/resources/resources.tsx
+++ b/ui/apps/everest/src/components/cluster-form/resources/resources.tsx
@@ -572,7 +572,6 @@ const ResourcesForm = ({
         onChange={handleAccordionChange('nodes')}
         sx={{
           px: 2,
-          backgroundColor: 'transparent',
         }}
       >
         <CustomAccordionSummary
@@ -603,7 +602,6 @@ const ResourcesForm = ({
           onChange={handleAccordionChange('proxies')}
           sx={{
             px: 2,
-            backgroundColor: 'transparent',
           }}
         >
           <CustomAccordionSummary

--- a/ui/apps/everest/src/components/cluster-form/resources/resources.tsx
+++ b/ui/apps/everest/src/components/cluster-form/resources/resources.tsx
@@ -572,6 +572,7 @@ const ResourcesForm = ({
         onChange={handleAccordionChange('nodes')}
         sx={{
           px: 2,
+          backgroundColor: 'transparent',
         }}
       >
         <CustomAccordionSummary
@@ -602,6 +603,7 @@ const ResourcesForm = ({
           onChange={handleAccordionChange('proxies')}
           sx={{
             px: 2,
+            backgroundColor: 'transparent',
           }}
         >
           <CustomAccordionSummary

--- a/ui/packages/design/src/themes/everest/EverestTheme.tsx
+++ b/ui/packages/design/src/themes/everest/EverestTheme.tsx
@@ -97,6 +97,13 @@ const everestThemeOptions = (mode: PaletteMode): ThemeOptions => {
           }),
         },
       },
+      MuiAccordion: {
+        styleOverrides: {
+          root: () => ({
+            backgroundColor: 'transparent',
+          }),
+        },
+      },
     },
   };
 


### PR DESCRIPTION
[EVEREST-1684](https://perconadev.atlassian.net/browse/EVEREST-1684)

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/4c7d69c5-b7fe-4b92-bfbb-634c1899afe9">


[EVEREST-1684]: https://perconadev.atlassian.net/browse/EVEREST-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ