### PR TITLE
[UI] EVEREST-1458 Empty State Fixes

### DIFF
--- a/ui/apps/everest/src/pages/databases/DbClusterView.tsx
+++ b/ui/apps/everest/src/pages/databases/DbClusterView.tsx
@@ -207,7 +207,8 @@ export const DbClusterView = () => {
             },
           })}
           renderTopToolbarCustomActions={() =>
-            canAddCluster && (
+            canAddCluster &&
+            tableData.length > 0 && (
               <Button
                 size="small"
                 startIcon={<AddIcon />}

--- a/ui/apps/everest/src/pages/databases/emptyState/emptyState.tsx
+++ b/ui/apps/everest/src/pages/databases/emptyState/emptyState.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Divider, Link, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Divider,
+  Link,
+  Typography,
+  useTheme,
+} from '@mui/material';
 import HelpIcon from '@mui/icons-material/Help';
 import AddIcon from '@mui/icons-material/Add';
 import { EmptyStateIcon } from '@percona/ui-lib';
@@ -12,6 +19,7 @@ const centeredContainerStyle = {
 };
 
 export const EmptyState = () => {
+  const theme = useTheme();
   return (
     <>
       <Box
@@ -39,7 +47,19 @@ export const EmptyState = () => {
         </Button>
         <Divider sx={{ width: '30%', marginTop: '10px' }} />
         <Link target="_blank" rel="noopener" href="https://hubs.ly/Q02Rt6pG0">
-          <Button startIcon={<HelpIcon />}> {Messages.contactSupport}</Button>
+          <Button
+            startIcon={
+              <HelpIcon
+                sx={{
+                  color: theme.palette.background.paper,
+                  backgroundColor: theme.palette.primary.main,
+                  borderRadius: '10px',
+                }}
+              />
+            }
+          >
+            {Messages.contactSupport}
+          </Button>
         </Link>
       </Box>
     </>

--- a/ui/packages/design/src/themes/base/BaseTheme.tsx
+++ b/ui/packages/design/src/themes/base/BaseTheme.tsx
@@ -791,6 +791,21 @@ const baseThemeOptions = (mode: PaletteMode): ThemeOptions => ({
         }),
       },
     },
+
+    MuiTableBody: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '#empty-state-icon': {
+            path: {
+              // complex selector we need in order to provide dark theme style for this icon, instead of having a separate one
+              '&:not(:nth-child(n+8)), &:last-child': {
+                stroke: theme.palette.text.primary,
+              },
+            },
+          },
+        }),
+      },
+    },
   },
 });
 

--- a/ui/packages/ui-lib/src/icons/empty-state/empty-state.tsx
+++ b/ui/packages/ui-lib/src/icons/empty-state/empty-state.tsx
@@ -1,6 +1,7 @@
 const EmptyStateIcon = ({ w, h }: { w: string; h: string }) => {
   return (
     <svg
+      id="empty-state-icon"
       width={w}
       height={h}
       viewBox="0 0 66 62"

--- a/ui/packages/ui-lib/src/icons/index.ts
+++ b/ui/packages/ui-lib/src/icons/index.ts
@@ -6,6 +6,8 @@ export * from './other';
 export * from './no-match';
 export { NoMatchIcon } from './no-match';
 
+export { EmptyStateIcon } from './empty-state';
+
 export * from './generic-error';
 
 export * from './status';


### PR DESCRIPTION
[EVEREST-1458](https://perconadev.atlassian.net/browse/EVEREST-1458)

- hide `Create Database` button from view if empty state is displayed
<img width="1706" alt="Screenshot 2024-11-26 at 16 14 26" src="https://github.com/user-attachments/assets/08fc6877-0497-40d2-8437-28b4098463c0">



- keep `Create Database` button on empty filter results and non-empty db list results
<img width="1701" alt="Screenshot 2024-11-26 at 16 22 16" src="https://github.com/user-attachments/assets/2b50e072-fa5c-44e5-b7ef-775b19d37e3e">
<img width="1685" alt="Screenshot 2024-11-26 at 16 22 29" src="https://github.com/user-attachments/assets/20401386-5437-4916-a0e2-7c1b6cfba6b4">



- fix info icon style
<img width="499" alt="image" src="https://github.com/user-attachments/assets/522fb21c-da48-4c38-b453-350be2fde17f">
<img width="321" alt="image" src="https://github.com/user-attachments/assets/3e43bc99-03e0-421b-9501-1e91938f9723">




- fix empty state icon style in dark mode 
[figma](https://www.figma.com/design/WasdpYdmJNoTn4zgFdHJcF/Everest-lib?node-id=1614-34489&node-type=instance&t=laU7OJ2gSgzgVaLI-0)
(this required using a complex css selector in order to override the colors and not use a different icon in dark theme) 
```
              '&:not(:nth-child(n+8)), &:last-child': {           
```
^ this selects all the elements that are not blue 
<img width="552" alt="image" src="https://github.com/user-attachments/assets/54e0e3e9-8d5f-479f-9dd5-9873cffe0067">





[EVEREST-1458]: https://perconadev.atlassian.net/browse/EVEREST-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ