### PR TITLE
EVEREST-1699 filter backup storages list based on RBAC permissions

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -275,6 +275,7 @@ func NewEnforceHandler(l *zap.SugaredLogger, basePath string, enforcer *casbin.E
 		allowedObjectsForListing := []string{
 			ResourceDatabaseClusters,
 			ResourceDatabaseEngines,
+			ResourceBackupStorages,
 		}
 		if slices.Contains(allowedObjectsForListing, resource) && name == "" && action == ActionRead {
 			return true, nil


### PR DESCRIPTION
EVEREST-1699

The backup storage listing operation must be allowed if a given user has permissions to read at least one backup storage but the list should be filtered to include only the allowed backup storages.