### PR TITLE
EVEREST-1698 filter monitoring instances list based on RBAC permissions

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -121,7 +121,7 @@ func (e *EverestServer) enforceDBClusterRBAC(user string, db *everestv1alpha1.Da
 	if mcName := pointer.Get(db.Spec.Monitoring).MonitoringConfigName; mcName != "" {
 		if err := e.enforce(user, rbac.ResourceMonitoringInstances, rbac.ActionRead, rbac.ObjectName(db.GetNamespace(), mcName)); err != nil {
 			if !errors.Is(err, errInsufficientPermissions) {
-				e.l.Error(errors.Join(err, errors.New("failed to check backup-storage permissions")))
+				e.l.Error(errors.Join(err, errors.New("failed to check monitoring-instance permissions")))
 			}
 			return err
 		}

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -276,6 +276,7 @@ func NewEnforceHandler(l *zap.SugaredLogger, basePath string, enforcer *casbin.E
 			ResourceDatabaseClusters,
 			ResourceDatabaseEngines,
 			ResourceBackupStorages,
+			ResourceMonitoringInstances,
 		}
 		if slices.Contains(allowedObjectsForListing, resource) && name == "" && action == ActionRead {
 			return true, nil


### PR DESCRIPTION
EVEREST-1698

The monitoring instance listing operation must be allowed if a given user has permissions to read at least one monitoring instance but the list should be filtered to include only the allowed monitoring instances.