### PR TITLE
EVEREST-1704 Remove pxc ConnectionURL

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -392,7 +392,6 @@ func (e *EverestServer) GetDatabaseClusterCredentials(ctx echo.Context, namespac
 	case everestv1alpha1.DatabaseEnginePXC:
 		response.Username = pointer.ToString("root")
 		response.Password = pointer.ToString(string(secret.Data["root"]))
-		response.ConnectionUrl = e.connectionURL(c, databaseCluster, *response.Username, *response.Password)
 	case everestv1alpha1.DatabaseEnginePSMDB:
 		response.Username = pointer.ToString(string(secret.Data["MONGODB_DATABASE_ADMIN_USER"]))
 		response.Password = pointer.ToString(string(secret.Data["MONGODB_DATABASE_ADMIN_PASSWORD"]))


### PR DESCRIPTION
EVEREST-1704

It was decided to not return the `ConnectionURL` for PXC from Everest API since there is no default format for such url. 