### PR TITLE
EVEREST-1712-fix-infinite-loop

### DIFF
--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -68,7 +68,8 @@ export const useNamespacePermissionsForResource = (
     create: [],
     delete: [],
   });
-  const { data: namespaces = [], isFetching } = useNamespaces();
+
+  const { data: namespaces, isFetching } = useNamespaces();
 
   const checkPermissions = useCallback(async () => {
     const newPermissions: Record<RBACAction, string[]> = {
@@ -79,6 +80,7 @@ export const useNamespacePermissionsForResource = (
     };
     const permissionsPromisesArr: Promise<void>[] = [];
 
+    if (namespaces) {
     for (const namespace of namespaces) {
       ['read', 'update', 'delete', 'create'].forEach((action) => {
         permissionsPromisesArr.push(
@@ -94,9 +96,8 @@ export const useNamespacePermissionsForResource = (
         );
       });
     }
-
+  }
     await Promise.all(permissionsPromisesArr);
-
     setPermissions(newPermissions);
   }, [namespaces, resource, specificResource]);
 

--- a/ui/apps/everest/src/hooks/rbac/rbac.ts
+++ b/ui/apps/everest/src/hooks/rbac/rbac.ts
@@ -81,22 +81,22 @@ export const useNamespacePermissionsForResource = (
     const permissionsPromisesArr: Promise<void>[] = [];
 
     if (namespaces) {
-    for (const namespace of namespaces) {
-      ['read', 'update', 'delete', 'create'].forEach((action) => {
-        permissionsPromisesArr.push(
-          can(
-            action as RBACAction,
-            resource,
-            `${namespace}/${specificResource}`
-          ).then((canDo) => {
-            if (canDo) {
-              newPermissions[action as RBACAction].push(namespace);
-            }
-          })
-        );
-      });
+      for (const namespace of namespaces) {
+        ['read', 'update', 'delete', 'create'].forEach((action) => {
+          permissionsPromisesArr.push(
+            can(
+              action as RBACAction,
+              resource,
+              `${namespace}/${specificResource}`
+            ).then((canDo) => {
+              if (canDo) {
+                newPermissions[action as RBACAction].push(namespace);
+              }
+            })
+          );
+        });
+      }
     }
-  }
     await Promise.all(permissionsPromisesArr);
     setPermissions(newPermissions);
   }, [namespaces, resource, specificResource]);


### PR DESCRIPTION
the useNamespace hook returns undefined data at a certain point, that leads to looping of checkPermissions function in ui/apps/everest/src/hooks/rbac/rbac.ts file because of default values = [] is anew every time