### PR TITLE
EVEREST-1740 Wrap ns update

### DIFF
--- a/pkg/cli/namespaces/remove.go
+++ b/pkg/cli/namespaces/remove.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/percona/everest/pkg/common"
 	"io"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"time"
 
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/percona/everest/pkg/cli/helm"
 	"github.com/percona/everest/pkg/cli/steps"
 	cliutils "github.com/percona/everest/pkg/cli/utils"
-	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 )
 
@@ -143,18 +143,24 @@ func NewRemoveNamespaceSteps(namespace string, keepNs bool, k *kubernetes.Kubern
 }
 
 func removeEverestLabelFromNamespace(ctx context.Context, k *kubernetes.Kubernetes, namespace string) error {
-	ns, err := k.GetNamespace(ctx, namespace)
-	if err != nil {
-		return err
-	}
-	if !isManagedByEverest(ns) {
-		return nil
-	}
-	labels := ns.GetLabels()
-	delete(labels, common.KubernetesManagedByLabel)
-	ns.SetLabels(labels)
-	_, err = k.UpdateNamespace(ctx, ns, v1.UpdateOptions{})
-	return err
+	return wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, false, func(ctx context.Context) (bool, error) {
+		ns, err := k.GetNamespace(ctx, namespace)
+		if err != nil {
+			return true, err
+		}
+		if !isManagedByEverest(ns) {
+			return true, nil
+		}
+		labels := ns.GetLabels()
+		delete(labels, common.KubernetesManagedByLabel)
+		ns.SetLabels(labels)
+		_, err = k.UpdateNamespace(ctx, ns, v1.UpdateOptions{})
+		if err != nil && k8serrors.IsConflict(err) {
+			return false, nil
+		}
+		return true, err
+	})
+
 }
 
 func ensureNamespaceGone(ctx context.Context, namespace string, k *kubernetes.Kubernetes) error {

--- a/pkg/cli/namespaces/remove.go
+++ b/pkg/cli/namespaces/remove.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/percona/everest/pkg/common"
 	"io"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"time"
 
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/percona/everest/pkg/cli/helm"
 	"github.com/percona/everest/pkg/cli/steps"
 	cliutils "github.com/percona/everest/pkg/cli/utils"
+	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 )
 
@@ -160,7 +160,6 @@ func removeEverestLabelFromNamespace(ctx context.Context, k *kubernetes.Kubernet
 		}
 		return true, err
 	})
-
 }
 
 func ensureNamespaceGone(ctx context.Context, namespace string, k *kubernetes.Kubernetes) error {


### PR DESCRIPTION
EVEREST-1740

The function that updates namespace may fail if other components have updated the namespace at the same time. 
This PR wraps the update function so it would retry if there is a conflict

