### PR TITLE
[UI] EVEREST-1750 Fix login focus, add info text for first storage in PITR modal

### DIFF
--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/pitr-details/edit-pitr.messages.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/pitr-details/edit-pitr.messages.tsx
@@ -8,4 +8,6 @@ export const Messages = {
     cancel: 'Cancel',
   },
   enablePITR: 'Enable PITR',
+  firstStorageWillBeUsed:
+    'The backup storage created for the initial schedule will be used for all subsequent schedules and PITR.',
 };

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/pitr-details/edit-pitr.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/pitr-details/edit-pitr.tsx
@@ -29,6 +29,7 @@ import { DbType } from '@percona/types';
 import PitrStorage from './pitr-storage';
 import { Messages as PITRMessages } from 'pages/common/pitr.messages';
 import { Messages } from './edit-pitr.messages';
+import { Typography } from '@mui/material';
 
 export const PitrEditModal = ({
   open,
@@ -73,6 +74,11 @@ export const PitrEditModal = ({
         backupStorageName
       )}
     >
+      {dbType === DbType.Mongo && (
+        <Typography variant="body2">
+          {Messages.firstStorageWillBeUsed}
+        </Typography>
+      )}
       <SwitchInput
         label={Messages.enablePITR}
         name={PitrEditFields.enabled}

--- a/ui/apps/everest/src/pages/login/Login.tsx
+++ b/ui/apps/everest/src/pages/login/Login.tsx
@@ -120,6 +120,7 @@ const Login = () => {
                   <TextInput
                     textFieldProps={{
                       type: 'text',
+                      autoFocus: true,
                       label: Messages.username,
                       fullWidth: true,
                       sx: { mb: 2 },


### PR DESCRIPTION
[EVEREST-1750](https://perconadev.atlassian.net/browse/EVEREST-1750)

Also added info text for first storage being used for mongo PITR.

![Screenshot 2024-12-13 at 14 51 19](https://github.com/user-attachments/assets/9f590d01-aff8-4d3a-9322-589bc41ca1fa)


[EVEREST-1750]: https://perconadev.atlassian.net/browse/EVEREST-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ