### PR TITLE
EVEREST-1752 | add support for more helm upgrade CLI flags

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -328,9 +328,9 @@ jobs:
             --operator.xtradb-cluster \
             --skip-wizard \
             --namespaces everest \
-            --helm-set server.image=localhost:5000/perconalab/everest \
-            --helm-set server.apiRequestsRateLimit=200 \
-            --helm-set versionMetadataURL=https://check-dev.percona.com
+            --helm.set server.image=localhost:5000/perconalab/everest \
+            --helm.set server.apiRequestsRateLimit=200 \
+            --helm.set versionMetadataURL=https://check-dev.percona.com
 
       - name: Expose Everest API Server
         run: |

--- a/cli-tests/Makefile
+++ b/cli-tests/Makefile
@@ -8,7 +8,7 @@ install-operators:  ## Install operators to k8s
 		--version-metadata-url https://check-dev.percona.com \
 		--namespaces percona-everest-operators \
 		--skip-wizard \
-		--helm-set versionMetadataURL=https://check-dev.percona.com
+		--helm.set versionMetadataURL=https://check-dev.percona.com
 
 test-cli:           ## Run all tests
 	npx playwright test --project=cli

--- a/commands/install.go
+++ b/commands/install.go
@@ -39,8 +39,8 @@ func newInstallCmd(l *zap.SugaredLogger) *cobra.Command {
 		//        Error: unknown command "a" for "everestctl install"
 		Args:    cobra.NoArgs,
 		Example: "everestctl install --namespaces dev,staging,prod --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard",
-		Long:    "Install Percona Everest Helm chart",
-		Short:   "Install Percona Everest",
+		Long:    "Install Percona Everest using Helm",
+		Short:   "Install Percona Everest using Helm",
 		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
 			initInstallViperFlags(cmd)
 			c := &install.Config{}
@@ -48,7 +48,7 @@ func newInstallCmd(l *zap.SugaredLogger) *cobra.Command {
 			if err != nil {
 				os.Exit(1)
 			}
-			bindInstallHelmOpts(c)
+			c.CLIOptions.BindViperFlags()
 
 			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
 			c.Pretty = !enableLogging
@@ -112,11 +112,4 @@ func initInstallViperFlags(cmd *cobra.Command) {
 
 	viper.BindPFlag(cli.FlagVerbose, cmd.Flags().Lookup(cli.FlagVerbose)) //nolint:errcheck,gosec
 	viper.BindPFlag("json", cmd.Flags().Lookup("json"))                   //nolint:errcheck,gosec
-}
-
-func bindInstallHelmOpts(cfg *install.Config) {
-	cfg.CLIOptions.Values.Values = viper.GetStringSlice(helm.FlagHelmSet)
-	cfg.CLIOptions.Values.ValueFiles = viper.GetStringSlice(helm.FlagHelmValues)
-	cfg.CLIOptions.ChartDir = viper.GetString(helm.FlagChartDir)
-	cfg.CLIOptions.RepoURL = viper.GetString(helm.FlagRepository)
 }

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -38,8 +38,8 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 		// it will return
 		//        Error: unknown command "a" for "everestctl upgrade"
 		Args:  cobra.NoArgs,
-		Long:  "Upgrade Percona Everest",
-		Short: "Upgrade Percona Everest",
+		Long:  "Upgrade Percona Everest using Helm",
+		Short: "Upgrade Percona Everest using Helm",
 		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
 			initUpgradeViperFlags(cmd)
 
@@ -47,7 +47,7 @@ func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
 			if err != nil {
 				os.Exit(1)
 			}
-			bindUpgradeHelmOpts(c)
+			c.CLIOptions.BindViperFlags()
 
 			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
 			c.Pretty = !enableLogging
@@ -77,6 +77,9 @@ func initUpgradeFlags(cmd *cobra.Command) {
 	cmd.Flags().String(helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
 	cmd.Flags().StringSlice(helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
 	cmd.Flags().StringSliceP(helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
+	cmd.Flags().Bool(helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
+	cmd.Flags().Bool(helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
+	cmd.Flags().Bool(helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
 
 	cmd.Flags().BoolP("logs", "l", false, "If set, logs are printed during the upgrade process")
 	cmd.Flags().Bool("dry-run", false, "If set, only executes the pre-upgrade checks")
@@ -94,19 +97,16 @@ func initUpgradeViperFlags(cmd *cobra.Command) {
 
 	viper.BindPFlag(upgrade.FlagSkipEnvDetection, cmd.Flags().Lookup(upgrade.FlagSkipEnvDetection)) //nolint:errcheck,gosec
 
-	viper.BindPFlag(helm.FlagRepository, cmd.Flags().Lookup(helm.FlagRepository)) //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmSet, cmd.Flags().Lookup(helm.FlagHelmSet))       //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmValues, cmd.Flags().Lookup(helm.FlagHelmValues)) //nolint:errcheck,gosec
+	viper.BindPFlag(helm.FlagRepository, cmd.Flags().Lookup(helm.FlagRepository))                             //nolint:errcheck,gosec
+	viper.BindPFlag(helm.FlagHelmSet, cmd.Flags().Lookup(helm.FlagHelmSet))                                   //nolint:errcheck,gosec
+	viper.BindPFlag(helm.FlagHelmValues, cmd.Flags().Lookup(helm.FlagHelmValues))                             //nolint:errcheck,gosec
+	viper.BindPFlag(helm.FlagHelmReuseValues, cmd.Flags().Lookup(helm.FlagHelmReuseValues))                   //nolint:errcheck,gosec
+	viper.BindPFlag(helm.FlagHelmResetValues, cmd.Flags().Lookup(helm.FlagHelmResetValues))                   //nolint:errcheck,gosec
+	viper.BindPFlag(helm.FlagHelmResetThenReuseValues, cmd.Flags().Lookup(helm.FlagHelmResetThenReuseValues)) //nolint:errcheck,gosec
 }
 
 func parseUpgradeConfig() (*upgrade.Config, error) {
 	c := &upgrade.Config{}
 	err := viper.Unmarshal(c)
 	return c, err
-}
-
-func bindUpgradeHelmOpts(cfg *upgrade.Config) {
-	cfg.CLIOptions.Values.Values = viper.GetStringSlice(helm.FlagHelmSet)
-	cfg.CLIOptions.Values.ValueFiles = viper.GetStringSlice(helm.FlagHelmValues)
-	cfg.CLIOptions.RepoURL = viper.GetString(helm.FlagRepository)
 }

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20241203113640-8dd4a9d32733
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213080644-ac14cc70dfe9
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213125842-25611d63cb26
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -2220,6 +2220,8 @@ github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213080644-ac14cc70dfe9 h1:yNgBVCeP0aq5MBc9T+AY8jWTEYNntZR+gfic8XC69Sw=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213080644-ac14cc70dfe9/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213125842-25611d63cb26 h1:uRrJYrNEl/egNtFXjDceLwxbPMcBB0iXiBcgFK4myCA=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213125842-25611d63cb26/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.18.0 h1:inRWonCOTacD++D/tvyFXVUqKx7f2OQzz8w1NyT3cAI=

--- a/go.sum
+++ b/go.sum
@@ -2218,8 +2218,6 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20241203113640-8dd4a9d32733 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20241203113640-8dd4a9d32733/go.mod h1:FTKcDBn/1BHKNDnocKBAWH2mG3BYyD6yLXtoS58o1BM=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h1:OggdqSzqe9pO3A4GaRlrLwZXS3zEQ84O4+7Jm9cg74s=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213080644-ac14cc70dfe9 h1:yNgBVCeP0aq5MBc9T+AY8jWTEYNntZR+gfic8XC69Sw=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213080644-ac14cc70dfe9/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213125842-25611d63cb26 h1:uRrJYrNEl/egNtFXjDceLwxbPMcBB0iXiBcgFK4myCA=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241213125842-25611d63cb26/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=

--- a/pkg/cli/helm/flags.go
+++ b/pkg/cli/helm/flags.go
@@ -4,9 +4,15 @@ const (
 	// FlagChartDir is a CLI flag for specifying the chart directory.
 	FlagChartDir = "chart-dir"
 	// FlagRepository is a CLI flag for specifying the Helm repository.
-	FlagRepository = "repository"
+	FlagRepository = "helm.repository"
 	// FlagHelmSet is a CLI flag for setting Helm values.
-	FlagHelmSet = "helm-set"
+	FlagHelmSet = "helm.set"
 	// FlagHelmValues is a CLI flag for specifying Helm values files.
-	FlagHelmValues = "helm-values"
+	FlagHelmValues = "helm.values"
+	// FlagHelmReuseValues is a CLI flag for reusing Helm values.
+	FlagHelmReuseValues = "helm.reuse-values"
+	// FlagHelmResetValues is a CLI flag for resetting Helm values.
+	FlagHelmResetValues = "helm.reset-values"
+	// FlagHelmResetThenReuseValues is a CLI flag for resetting then reusing Helm values.
+	FlagHelmResetThenReuseValues = "helm.reset-then-reuse-values"
 )

--- a/pkg/cli/helm/installer.go
+++ b/pkg/cli/helm/installer.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -43,10 +44,25 @@ var settings = helmcli.New() //nolint:gochecknoglobals
 
 // CLIOptions contains common options for the CLI.
 type CLIOptions struct {
-	ChartDir string
-	RepoURL  string
-	Values   values.Options
-	Devel    bool
+	ChartDir             string
+	RepoURL              string
+	Values               values.Options
+	Devel                bool
+	ReuseValues          bool
+	ResetValues          bool
+	ResetThenReuseValues bool
+}
+
+// BindViperFlags parses the CLI flags from Viper and binds them to the CLI options.
+func (o *CLIOptions) BindViperFlags() {
+	o.Values.Values = viper.GetStringSlice(FlagHelmSet)
+	o.Values.ValueFiles = viper.GetStringSlice(FlagHelmValues)
+	o.ChartDir = viper.GetString(FlagChartDir)
+	o.RepoURL = viper.GetString(FlagRepository)
+	o.RepoURL = viper.GetString(FlagRepository)
+	o.ReuseValues = viper.GetBool(FlagHelmReuseValues)
+	o.ResetValues = viper.GetBool(FlagHelmResetValues)
+	o.ResetThenReuseValues = viper.GetBool(FlagHelmResetThenReuseValues)
 }
 
 // Everest Helm chart names.
@@ -208,8 +224,10 @@ func (i *Installer) install(ctx context.Context) error {
 
 // UpgradeOptions provide options for upgrading a Helm chart.
 type UpgradeOptions struct {
-	DisableHooks bool
-	ReuseValues  bool
+	DisableHooks         bool
+	ReuseValues          bool
+	ResetValues          bool
+	ResetThenReuseValues bool
 }
 
 // Upgrade the Helm chart.
@@ -218,6 +236,8 @@ func (i *Installer) Upgrade(ctx context.Context, opts UpgradeOptions) error {
 	upgrade.Namespace = i.ReleaseNamespace
 	upgrade.TakeOwnership = true
 	upgrade.ReuseValues = opts.ReuseValues
+	upgrade.ResetValues = opts.ResetValues
+	upgrade.ResetThenReuseValues = opts.ResetThenReuseValues
 	upgrade.DisableHooks = opts.DisableHooks
 
 	rel, err := upgrade.RunWithContext(ctx, i.ReleaseName, i.chart, i.Values)

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -113,7 +113,11 @@ func (u *Upgrade) upgradeHelmChart(ctx context.Context) error {
 		return fmt.Errorf("could not upgrade DB namespaces Helm charts: %w", err)
 	}
 	// Upgrade the main chart.
-	return u.helmInstaller.Upgrade(ctx, helm.UpgradeOptions{})
+	return u.helmInstaller.Upgrade(ctx, helm.UpgradeOptions{
+		ReuseValues:          u.config.ReuseValues,
+		ResetValues:          u.config.ResetValues,
+		ResetThenReuseValues: u.config.ResetThenReuseValues,
+	})
 }
 
 func (u *Upgrade) upgradeEverestDBNamespaceHelmCharts(ctx context.Context) error {


### PR DESCRIPTION
There’s an issue with Helm where during upgrades, if you provide values using `--set` (or equivalent flags), it will reset the values back to the defaults built into the chart.

To tweak this behaviour, helm offers the following 3 flags: reuse-values, reset-values and reset-then-reuse-values.

Each of these options changes the way values are applied during upgrades. Since we provide an option to change the Helm values from the CLI, we need to provide these flags as well.