### PR TITLE
EVEREST-1762, 1750 | Improvements to namespaces cmd

### DIFF
--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -17,7 +17,10 @@ import (
 )
 
 //nolint:gochecknoglobals
-var takeOwnershipHintMessage = fmt.Sprintf("HINT: set '--%s' flag to use existing namespaces", cli.FlagTakeNamespaceOwnership)
+var (
+	takeOwnershipHintMessage = fmt.Sprintf("HINT: set '--%s' flag to use existing namespaces", cli.FlagTakeNamespaceOwnership)
+	updateHindMessage        = "HINT: use 'everestctl namespaces update' to update the namespace"
+)
 
 // NewAddCommand returns a new command to add a new namespace.
 func NewAddCommand(l *zap.SugaredLogger) *cobra.Command {
@@ -52,6 +55,9 @@ func NewAddCommand(l *zap.SugaredLogger) *cobra.Command {
 			if err := c.Populate(cmd.Context(), false, askOperators); err != nil {
 				if errors.Is(err, namespaces.ErrNamespaceAlreadyExists) {
 					err = fmt.Errorf("%w. %s", err, takeOwnershipHintMessage)
+				}
+				if errors.Is(err, namespaces.ErrNamespaceAlreadyOwned) {
+					err = fmt.Errorf("%w. %s", err, updateHindMessage)
 				}
 				output.PrintError(err, l, !enableLogging)
 				os.Exit(1)

--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -19,7 +19,7 @@ import (
 //nolint:gochecknoglobals
 var (
 	takeOwnershipHintMessage = fmt.Sprintf("HINT: set '--%s' flag to use existing namespaces", cli.FlagTakeNamespaceOwnership)
-	updateHindMessage        = "HINT: use 'everestctl namespaces update' to update the namespace"
+	updateHintMessage        = "HINT: use 'everestctl namespaces update' to update the namespace"
 )
 
 // NewAddCommand returns a new command to add a new namespace.

--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -57,7 +57,7 @@ func NewAddCommand(l *zap.SugaredLogger) *cobra.Command {
 					err = fmt.Errorf("%w. %s", err, takeOwnershipHintMessage)
 				}
 				if errors.Is(err, namespaces.ErrNamespaceAlreadyOwned) {
-					err = fmt.Errorf("%w. %s", err, updateHindMessage)
+					err = fmt.Errorf("%w. %s", err, updateHintMessage)
 				}
 				output.PrintError(err, l, !enableLogging)
 				os.Exit(1)

--- a/pkg/cli/namespaces/add.go
+++ b/pkg/cli/namespaces/add.go
@@ -196,7 +196,7 @@ var (
 	// ErrNamespaceAlreadyExists appears when the namespace already exists.
 	ErrNamespaceAlreadyExists = errors.New("namespace already exists")
 	// ErrNamespaceAlreadyOwned appears when the namespace is already owned by Everest.
-	ErrNamespaceAlreadyOwned = errors.New("namespace already exists and managed by Everest")
+	ErrNamespaceAlreadyOwned = errors.New("namespace already exists and is managed by Everest")
 )
 
 func (cfg *NamespaceAddConfig) validateNamespaceOwnership(

--- a/pkg/cli/namespaces/add.go
+++ b/pkg/cli/namespaces/add.go
@@ -135,23 +135,23 @@ func (n *NamespaceAdder) Run(ctx context.Context) error {
 		defer cleanup()
 	}
 
-	for _, namespace := range n.cfg.NamespaceList {
-		installSteps = append(installSteps,
-			n.newStepInstallNamespace(ver, namespace),
-		)
-	}
-
 	// validate operators for each namespace.
 	for _, namespace := range n.cfg.NamespaceList {
 		err := n.validateNamespace(ctx, namespace)
 		if errors.Is(err, errCannotRemoveOperators) {
 			msg := "Removal of an installed operator is not supported. Proceeding without removal."
-			output.Warn(msg) //nolint:govet
+			fmt.Fprintf(os.Stdout, output.Warn(msg))
 			n.l.Warn(msg)
 			break
 		} else if err != nil {
 			return fmt.Errorf("namespace validation error: %w", err)
 		}
+	}
+
+	for _, namespace := range n.cfg.NamespaceList {
+		installSteps = append(installSteps,
+			n.newStepInstallNamespace(ver, namespace),
+		)
 	}
 
 	var out io.Writer = os.Stdout

--- a/pkg/cli/namespaces/add.go
+++ b/pkg/cli/namespaces/add.go
@@ -140,7 +140,7 @@ func (n *NamespaceAdder) Run(ctx context.Context) error {
 		err := n.validateNamespace(ctx, namespace)
 		if errors.Is(err, errCannotRemoveOperators) {
 			msg := "Removal of an installed operator is not supported. Proceeding without removal."
-			fmt.Fprintf(os.Stdout, output.Warn(msg))
+			fmt.Fprint(os.Stdout, output.Warn(msg)) //nolint:govet
 			n.l.Warn(msg)
 			break
 		} else if err != nil {

--- a/pkg/cli/namespaces/add.go
+++ b/pkg/cli/namespaces/add.go
@@ -146,7 +146,7 @@ func (n *NamespaceAdder) Run(ctx context.Context) error {
 		err := n.validateNamespace(ctx, namespace)
 		if errors.Is(err, errCannotRemoveOperators) {
 			msg := "Removal of an installed operator is not supported. Proceeding without removal."
-			output.Warn(msg)
+			output.Warn(msg) //nolint:govet
 			n.l.Warn(msg)
 			break
 		} else if err != nil {
@@ -264,7 +264,7 @@ func (n *NamespaceAdder) provisionDBNamespace(
 	return installer.Install(ctx)
 }
 
-// Returns: [exists, managedByEverest, error]
+// Returns: [exists, managedByEverest, error].
 func namespaceExists(
 	ctx context.Context,
 	namespace string,
@@ -436,7 +436,8 @@ func (n *NamespaceAdder) validateNamespaceUpdate(ctx context.Context, namespace 
 		return fmt.Errorf("cannot list subscriptions: %w", err)
 	}
 	if !ensureNoOperatorsRemoved(subscriptions.Items,
-		n.cfg.Operator.PG, n.cfg.Operator.PXC, n.cfg.Operator.PSMDB) {
+		n.cfg.Operator.PG, n.cfg.Operator.PXC, n.cfg.Operator.PSMDB,
+	) {
 		return errCannotRemoveOperators
 	}
 	return nil

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -260,6 +260,11 @@ func (k *Kubernetes) GetSubscription(ctx context.Context, name, namespace string
 	return k.client.OLM().OperatorsV1alpha1().Subscriptions(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
+// ListSubscriptions lists subscriptions.
+func (k *Kubernetes) ListSubscriptions(ctx context.Context, namespace string) (*olmv1alpha1.SubscriptionList, error) {
+	return k.client.OLM().OperatorsV1alpha1().Subscriptions(namespace).List(ctx, metav1.ListOptions{})
+}
+
 // InstallOperatorRequest holds the fields to make an operator install request.
 type InstallOperatorRequest struct {
 	Namespace              string

--- a/pkg/kubernetes/kubernetes_interface.go
+++ b/pkg/kubernetes/kubernetes_interface.go
@@ -86,6 +86,8 @@ type KubernetesConnector interface {
 	DeleteCatalogSource(ctx context.Context, name, namespace string) error
 	// GetSubscription returns subscription.
 	GetSubscription(ctx context.Context, name, namespace string) (*olmv1alpha1.Subscription, error)
+	// ListSubscriptions lists subscriptions.
+	ListSubscriptions(ctx context.Context, namespace string) (*olmv1alpha1.SubscriptionList, error)
 	// GetServerVersion returns server version.
 	GetServerVersion() (*version.Info, error)
 	// GetClusterServiceVersion retrieves a ClusterServiceVersion by namespaced name.

--- a/pkg/kubernetes/mock_kubernetes_connector.go
+++ b/pkg/kubernetes/mock_kubernetes_connector.go
@@ -1237,6 +1237,36 @@ func (_m *MockKubernetesConnector) ListSecrets(ctx context.Context, namespace st
 	return r0, r1
 }
 
+// ListSubscriptions provides a mock function with given fields: ctx, namespace
+func (_m *MockKubernetesConnector) ListSubscriptions(ctx context.Context, namespace string) (*operatorsv1alpha1.SubscriptionList, error) {
+	ret := _m.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListSubscriptions")
+	}
+
+	var r0 *operatorsv1alpha1.SubscriptionList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*operatorsv1alpha1.SubscriptionList, error)); ok {
+		return rf(ctx, namespace)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *operatorsv1alpha1.SubscriptionList); ok {
+		r0 = rf(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*operatorsv1alpha1.SubscriptionList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Namespace provides a mock function with given fields:
 func (_m *MockKubernetesConnector) Namespace() string {
 	ret := _m.Called()

--- a/pkg/output/command.go
+++ b/pkg/output/command.go
@@ -85,10 +85,15 @@ func Failure(msg string, args ...any) string {
 
 // Info prints a message with an info emoji.
 func Info(msg string, args ...any) string {
-	return fmt.Sprintf("ℹ️ %s\n", fmt.Sprintf(msg, args...))
+	return fmt.Sprintf("ℹ️  %s\n", fmt.Sprintf(msg, args...))
 }
 
 // Rocket prints a message with a rocket emoji.
 func Rocket(msg string, args ...any) string {
 	return fmt.Sprintf("🚀 %s\n", fmt.Sprintf(msg, args...))
+}
+
+// Warn prints a message with a warning emoji.
+func Warn(msg string, args ...any) string {
+	return fmt.Sprintf("⚠️  %s\n", fmt.Sprintf(msg, args...))
 }


### PR DESCRIPTION
Adds the following improvements to the namespaces command;

1. Setting `--take-ownership` for a namespace which is already managed by everest throws an error:
```sh
❯ ./bin/everestctl namespaces add everest --take-ownership
× invalid namespace (everest): namespace already exists and is managed by Everest. HINT: use 'everestctl namespaces update' to update the namespace
```
3. Trying to remove an operator shows a warning (note that the prevention of the removal is handled by the helm chart itself):
```sh
❯ ./bin/everestctl namespaces update everest                                                                                                               ││                                                                                                                                                        
? Which operators do you want to install? MongoDB, PostgreSQL                                                                                              ││                                                                                                                                                        │
⚠️   Removal of an installed operator is not supported. Proceeding without removal.                                                                         ││                                                                                                                                                        │
✓ Updating namespace 'everest'
```
