### PR TITLE
EVEREST-1768, EVEREST-1766 | improvements for `namespaces remove` command

### DIFF
--- a/pkg/kubernetes/database_cluster.go
+++ b/pkg/kubernetes/database_cluster.go
@@ -65,7 +65,7 @@ func (k *Kubernetes) DeleteDatabaseClusters(ctx context.Context, namespace strin
 			return true, nil
 		}
 		for _, cluster := range list.Items {
-			if err := k.DeleteDatabaseCluster(ctx, cluster.GetNamespace(), cluster.GetName()); err != nil {
+			if err := k.DeleteDatabaseCluster(ctx, cluster.GetNamespace(), cluster.GetName()); ctrlclient.IgnoreNotFound(err) != nil {
 				return false, err
 			}
 		}


### PR DESCRIPTION
* ignore `NotFound` error when trying to delete a DB cluster
* throw a warning when trying to remove a namespace that does not exist