### PR TITLE
EVEREST-1563 unify FB version

### DIFF
--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -350,8 +350,8 @@ jobs:
 
       - name: Everest - build binary
         run: |
-          RELEASE_VERSION=${VERSION} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make rc
-          RELEASE_VERSION=${VERSION} make release-cli
+          RELEASE_VERSION=${VERSION_TAG} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make rc
+          RELEASE_VERSION=${VERSION_TAG} make release-cli
 
       - name: Upload CLI artefacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
EVEREST-1563

The FB version wasn't displayed with the `v` prefix which is used for other builds (RC/Release/dev), this PR fixes it