### PR TITLE
EVEREST-107 fix playwright config for slow chrome

### DIFF
--- a/ui/apps/everest/.e2e/playwright.config.ts
+++ b/ui/apps/everest/.e2e/playwright.config.ts
@@ -92,8 +92,6 @@ export default defineConfig({
     {
       name: 'pr',
       use: {
-        browserName: 'chromium',
-        channel: 'chrome',
         storageState: STORAGE_STATE_FILE,
       },
       testDir: 'pr',
@@ -102,8 +100,6 @@ export default defineConfig({
     {
       name: 'release',
       use: {
-        browserName: 'chromium',
-        channel: 'chrome',
         storageState: STORAGE_STATE_FILE,
         actionTimeout: 10000,
       },
@@ -113,8 +109,6 @@ export default defineConfig({
     {
       name: 'upgrade',
       use: {
-        browserName: 'chromium',
-        channel: 'chrome',
         storageState: STORAGE_STATE_FILE,
         video: 'retain-on-failure',
         actionTimeout: 10000,


### PR DESCRIPTION
EVEREST-107

With the old settings the `pr` `release` `upgrade` test suits were running slowly locally because they were launching Chrome instead of Chromium. So if Chrome is slow on your machine, you'll get the timeouts. 
This PR updates the settings so that all tests are running in Chromium by default