### PR TITLE
EVEREST-1789, EVEREST-1983 | [CLI] 'namespaces remove' command should remove Everest namespaces only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20241203113640-8dd4a9d32733
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241220144602-ed5f74ec7b75
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241226165327-04f582fcfc45
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -2226,8 +2226,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20241203113640-8dd4a9d32733 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20241203113640-8dd4a9d32733/go.mod h1:FTKcDBn/1BHKNDnocKBAWH2mG3BYyD6yLXtoS58o1BM=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h1:OggdqSzqe9pO3A4GaRlrLwZXS3zEQ84O4+7Jm9cg74s=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241220144602-ed5f74ec7b75 h1:BFRgcLI/NyHmc2D5p/uC1gB6BUBevXDGZyKYpKHhhHA=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241220144602-ed5f74ec7b75/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241226165327-04f582fcfc45 h1:StEj7V4VEGrgKZRWCpRHg45IogTNOxkWinpnegqgCv8=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20241226165327-04f582fcfc45/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.18.0 h1:inRWonCOTacD++D/tvyFXVUqKx7f2OQzz8w1NyT3cAI=

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -221,7 +221,7 @@ func (o *Install) printPostInstallMessage(out io.Writer) {
 
 	message += bold("ACCESS THE EVEREST UI:\n\n")
 	message += "To access the web UI, set up port-forwarding and visit http://localhost:8080 in your browser:\n\n"
-	message += "\tkubectl port-forward -n everest-system svc/everest-server 8080:80"
+	message += "\tkubectl port-forward -n everest-system svc/everest 8080:8080"
 	message += "\n"
 
 	fmt.Fprint(out, message)

--- a/pkg/cli/namespaces/remove.go
+++ b/pkg/cli/namespaces/remove.go
@@ -89,13 +89,14 @@ func (r *NamespaceRemover) Run(ctx context.Context) error {
 	removalSteps := []steps.Step{}
 	for _, ns := range r.config.Namespaces {
 		// Check that the namespace exists.
-		_, err := r.kubeClient.GetNamespace(ctx, ns)
-		if k8serrors.IsNotFound(err) {
-			r.l.Infof("Namespace '%s' does not exist", ns)
-			fmt.Fprint(os.Stdout, output.Warn("Namespace (%s) does not exist, skipping..", ns))
+		exists, managedByEverest, err := namespaceExists(ctx, ns, r.kubeClient)
+		if err != nil {
+			return errors.Join(err, errors.New("failed to check if namespace exists"))
+		}
+		if !exists || !managedByEverest {
+			r.l.Infof("Namespace '%s' does not exist or not managed by Everest", ns)
+			fmt.Fprint(os.Stdout, output.Warn("Namespace (%s) does not exist or not managed by Everest, skipping..", ns))
 			continue
-		} else if err != nil {
-			return errors.Join(err, errors.New("failed to get namespace"))
 		}
 		removalSteps = append(removalSteps, NewRemoveNamespaceSteps(ns, r.config.KeepNamespace, r.kubeClient)...)
 	}


### PR DESCRIPTION
* adds a check to ensure that the namespace specified in 'namespaces remove' command contains the 'app.kubernetes.io/managed-by=everest' label
* fixes some typos in post installation message