### PR TITLE
EVEREST-1762 | Fix helm migration from 1.3 to 1.4

### DIFF
--- a/pkg/cli/helm/installer.go
+++ b/pkg/cli/helm/installer.go
@@ -228,6 +228,7 @@ type UpgradeOptions struct {
 	ReuseValues          bool
 	ResetValues          bool
 	ResetThenReuseValues bool
+	Force                bool
 }
 
 // Upgrade the Helm chart.
@@ -239,6 +240,7 @@ func (i *Installer) Upgrade(ctx context.Context, opts UpgradeOptions) error {
 	upgrade.ResetValues = opts.ResetValues
 	upgrade.ResetThenReuseValues = opts.ResetThenReuseValues
 	upgrade.DisableHooks = opts.DisableHooks
+	upgrade.Force = opts.Force
 
 	rel, err := upgrade.RunWithContext(ctx, i.ReleaseName, i.chart, i.Values)
 	if err != nil {

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -212,6 +212,7 @@ func (u *Upgrade) helmAdoptDBNamespaces(ctx context.Context, namespace, version 
 	return installer.Upgrade(ctx, helm.UpgradeOptions{
 		DisableHooks: true,
 		ReuseValues:  true,
+		Force:        true, // since the version is not changing, we want to ensure that new manifests are still applied.
 	})
 }
 

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -241,7 +241,7 @@ func (u *Upgrade) printPostUpgradeMessage(ctx context.Context, out io.Writer) er
 	if isSecure, err := u.kubeClient.Accounts().IsSecure(ctx, common.EverestAdminUser); err != nil {
 		return errors.Join(err, errors.New("could not check if the admin password is secure"))
 	} else if !isSecure {
-		fmt.Fprint(os.Stdout, "\n", common.InitialPasswordWarningMessage)
+		fmt.Fprint(os.Stdout, "\n", common.InitialPasswordWarningMessage, "\n")
 	}
 	return nil
 }


### PR DESCRIPTION
In the Helm chart, we added a `helm.sh/resource-policy=keep` annotation to the Subscription to ensure that they cannot be removed during update operations. However, the new Subscription is not applied by helm since it already exists. This PR adds the `force=true` option so that the new Subscription annotations are applied.