### PR TITLE
EVEREST-1709 | Update RBAC permissions & tests

### DIFF
--- a/internal/server/handlers/rbac/database_cluster.go
+++ b/internal/server/handlers/rbac/database_cluster.go
@@ -30,9 +30,9 @@ func (h *rbacHandler) CreateDatabaseCluster(ctx context.Context, db *everestv1al
 
 	schedules := db.Spec.Backup.Schedules
 	if len(schedules) > 0 {
-		// To create a cluster with backup schedules, the user needs to explicitly have permissions to take backups.
+		// To create a cluster with backup schedules, the user needs to explicitly have permissions to take backups for this cluster.
 		if err := h.enforce(ctx, rbac.ResourceDatabaseClusterBackups, rbac.ActionCreate,
-			rbac.ObjectName(namespace, ""),
+			rbac.ObjectName(namespace, db.GetName()),
 		); err != nil {
 			return nil, err
 		}
@@ -50,7 +50,7 @@ func (h *rbacHandler) CreateDatabaseCluster(ctx context.Context, db *everestv1al
 	if dataSrc := db.Spec.DataSource; dataSrc != nil && dataSrc.DBClusterBackupName != "" {
 		sourceBackup := dataSrc.DBClusterBackupName
 		if err := h.enforce(ctx, rbac.ResourceDatabaseClusterRestores,
-			rbac.ActionCreate, rbac.ObjectName(namespace, ""),
+			rbac.ActionCreate, rbac.ObjectName(namespace, db.GetName()),
 		); err != nil {
 			return nil, err
 		}
@@ -140,9 +140,9 @@ func (h *rbacHandler) UpdateDatabaseCluster(ctx context.Context, db *everestv1al
 		return true
 	}
 
-	// If shedules are updated, user should have permissions to create a backup.
+	// If shedules are updated, user should have permissions to create a backup for this cluster.
 	if !isSchedEqual() {
-		if err := h.enforce(ctx, rbac.ResourceDatabaseClusterBackups, rbac.ActionCreate, rbac.ObjectName(oldDB.GetNamespace(), "")); err != nil {
+		if err := h.enforce(ctx, rbac.ResourceDatabaseClusterBackups, rbac.ActionCreate, rbac.ObjectName(oldDB.GetNamespace(), db.GetName())); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/server/handlers/rbac/database_cluster_restore.go
+++ b/internal/server/handlers/rbac/database_cluster_restore.go
@@ -72,6 +72,9 @@ func (h *rbacHandler) UpdateDatabaseClusterRestore(ctx context.Context, req *eve
 	if err := h.enforce(ctx, rbac.ResourceDatabaseClusterRestores, rbac.ActionUpdate, rbac.ObjectName(namespace, clusterName)); err != nil {
 		return nil, err
 	}
+	if err := h.enforceDBRestore(ctx, namespace, clusterName); err != nil {
+		return nil, err
+	}
 	return h.next.UpdateDatabaseClusterRestore(ctx, req)
 }
 

--- a/internal/server/handlers/rbac/database_cluster_restore_test.go
+++ b/internal/server/handlers/rbac/database_cluster_restore_test.go
@@ -300,12 +300,61 @@ func TestRBAC_DatabaseClusterRestore(t *testing.T) {
 				desc: "success",
 				policy: newPolicy(
 					"p, role:test, database-cluster-restores, update, default/cluster1",
+					"p, role:test, database-cluster-credentials, read, default/cluster1",
+					"p, role:test, database-cluster-backups, read, default/cluster1",
+					"p, role:test, database-cluster-restores, read, default/cluster1",
 					"g, bob, role:test",
 				),
 			},
 			{
-				desc:    "missing update permission for database-cluster-restores on 'cluster1'",
-				policy:  newPolicy(),
+				desc: "missing update permission for database-cluster-restores on 'cluster1'",
+				policy: newPolicy(
+					"p, role:test, database-cluster-credentials, read, default/cluster1",
+					"p, role:test, database-cluster-backups, read, default/cluster1",
+					"p, role:test, database-cluster-restores, read, default/cluster1",
+					"g, bob, role:test",
+				),
+				wantErr: ErrInsufficientPermissions,
+			},
+			{
+				desc: "has create permission for database-cluster-restores on 'cluster1'",
+				policy: newPolicy(
+					"p, role:test, database-cluster-restores, create, default/cluster1",
+					"p, role:test, database-cluster-credentials, read, default/cluster1",
+					"p, role:test, database-cluster-backups, read, default/cluster1",
+					"p, role:test, database-cluster-restores, read, default/cluster1",
+					"g, bob, role:test",
+				),
+				wantErr: ErrInsufficientPermissions,
+			},
+			{
+				desc: "missing read permission for database-cluster-credentials on 'cluster1'",
+				policy: newPolicy(
+					"p, role:test, database-cluster-restores, update, default/cluster1",
+					"p, role:test, database-cluster-backups, read, default/cluster1",
+					"p, role:test, database-cluster-restores, read, default/cluster1",
+					"g, bob, role:test",
+				),
+				wantErr: ErrInsufficientPermissions,
+			},
+			{
+				desc: "missing read permission for database-cluster-backups on 'cluster1'",
+				policy: newPolicy(
+					"p, role:test, database-cluster-restores, update, default/cluster1",
+					"p, role:test, database-cluster-credentials, read, default/cluster1",
+					"p, role:test, database-cluster-restores, read, default/cluster1",
+					"g, bob, role:test",
+				),
+				wantErr: ErrInsufficientPermissions,
+			},
+			{
+				desc: "missing read permission for database-cluster-restores on 'cluster1'",
+				policy: newPolicy(
+					"p, role:test, database-cluster-restores, update, default/cluster1",
+					"p, role:test, database-cluster-credentials, read, default/cluster1",
+					"p, role:test, database-cluster-backups, read, default/cluster1",
+					"g, bob, role:test",
+				),
 				wantErr: ErrInsufficientPermissions,
 			},
 		}

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -258,34 +258,6 @@ func buildPathResourceMap(basePath string) (map[string]string, []string, error) 
 	return resourceMap, skipPaths, nil
 }
 
-func isAllowedRBAC(name, action, resource string) bool {
-	// Allow creating objects without a name.
-	// RBAC is enforced in the individual methods.
-	allowedObjectsForCreateWithoutName := []string{
-		ResourceDatabaseClusterRestores,
-		ResourceDatabaseClusterBackups,
-	}
-	if name == "" && action == ActionCreate && slices.Contains(allowedObjectsForCreateWithoutName, resource) {
-		return true
-	}
-
-	// Listing the following objects is always allowed here,
-	// since we will filter the output of the list itself based on the permissions.
-	allowedObjectsForListing := []string{
-		ResourceDatabaseClusters,
-		ResourceDatabaseEngines,
-		ResourceBackupStorages,
-		ResourceMonitoringInstances,
-		ResourceDatabaseClusterRestores,
-		ResourceDatabaseClusterBackups,
-	}
-	if slices.Contains(allowedObjectsForListing, resource) && name == "" && action == ActionRead {
-		return true
-	}
-
-	return false
-}
-
 // NewSkipper returns a new function that checks if a given request should be skipped
 // from RBAC checks.
 func NewSkipper(basePath string) (func(echo.Context) bool, error) {


### PR DESCRIPTION
* Fix some leftovers from [EVEREST-1707](https://perconadev.atlassian.net/browse/EVEREST-1707) - DBR permissions must use the cluster name
* `UpdateDatabaseClusterRestores` should have the same set permissions as `CreateDatabaseClusterRestores` 

[EVEREST-1707]: https://perconadev.atlassian.net/browse/EVEREST-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ