### PR TITLE
EVEREST-107 increase tests timeout

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   test:
     name: Test
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We added more tests so the CI sometimes fails with timeout. 