### PR TITLE
Everest 1673 custom helm dir in db namespaces

### DIFF
--- a/pkg/cli/namespaces/add.go
+++ b/pkg/cli/namespaces/add.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 
@@ -27,11 +26,6 @@ import (
 	"github.com/percona/everest/pkg/output"
 	. "github.com/percona/everest/pkg/utils/must" //nolint:revive,stylecheck
 	"github.com/percona/everest/pkg/version"
-)
-
-const (
-	// Path to the everest-db-namespace subchart, relative to the main chart.
-	dbNamespaceSubChartPath = "/charts/everest-db-namespace"
 )
 
 //nolint:gochecknoglobals
@@ -271,10 +265,6 @@ func (n *NamespaceAdder) provisionDBNamespace(
 	if err != nil {
 		return err
 	}
-	chartDir := ""
-	if n.cfg.ChartDir != "" {
-		chartDir = path.Join(n.cfg.ChartDir, dbNamespaceSubChartPath)
-	}
 	values := Must(helmutils.MergeVals(n.getValues(), nil))
 	installer := helm.Installer{
 		ReleaseName:            namespace,
@@ -283,7 +273,7 @@ func (n *NamespaceAdder) provisionDBNamespace(
 		CreateReleaseNamespace: !nsExists,
 	}
 	if err := installer.Init(n.cfg.KubeconfigPath, helm.ChartOptions{
-		Directory: chartDir,
+		Directory: cliutils.DBNamespaceSubChartPath(n.cfg.ChartDir),
 		URL:       n.cfg.RepoURL,
 		Name:      helm.EverestDBNamespaceChartName,
 		Version:   version,

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -3,8 +3,6 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-
 	"github.com/AlekSi/pointer"
 	"helm.sh/helm/v3/pkg/cli/values"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -16,6 +14,7 @@ import (
 	"github.com/percona/everest/pkg/cli/helm"
 	helmutils "github.com/percona/everest/pkg/cli/helm/utils"
 	"github.com/percona/everest/pkg/cli/steps"
+	"github.com/percona/everest/pkg/cli/utils"
 	"github.com/percona/everest/pkg/common"
 	"github.com/percona/everest/pkg/kubernetes"
 	. "github.com/percona/everest/pkg/utils/must" //nolint:revive,stylecheck
@@ -140,9 +139,10 @@ func (u *Upgrade) upgradeEverestDBNamespaceHelmChart(ctx context.Context, namesp
 		ReleaseNamespace: namespace,
 	}
 	if err := installer.Init(u.config.KubeconfigPath, helm.ChartOptions{
-		URL:     u.config.RepoURL,
-		Name:    helm.EverestDBNamespaceChartName,
-		Version: u.upgradeToVersion,
+		URL:       u.config.RepoURL,
+		Directory: utils.DBNamespaceSubChartPath(u.config.ChartDir),
+		Name:      helm.EverestDBNamespaceChartName,
+		Version:   u.upgradeToVersion,
 	}); err != nil {
 		return fmt.Errorf("could not initialize Helm installer: %w", err)
 	}
@@ -191,13 +191,9 @@ func (u *Upgrade) helmAdoptDBNamespaces(ctx context.Context, namespace, version 
 		Values:           values,
 	}
 
-	var directory string
-	if u.config.ChartDir != "" {
-		directory = filepath.Join(u.config.ChartDir, "charts/everest-db-namespace")
-	}
 	if err := installer.Init(u.config.KubeconfigPath, helm.ChartOptions{
 		URL:       u.config.RepoURL,
-		Directory: directory,
+		Directory: utils.DBNamespaceSubChartPath(u.config.ChartDir),
 		Name:      helm.EverestDBNamespaceChartName,
 		Version:   version,
 	}); err != nil {

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"fmt"
+
 	"github.com/AlekSi/pointer"
 	"helm.sh/helm/v3/pkg/cli/values"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/cli/utils/utils.go
+++ b/pkg/cli/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"path"
 
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -13,6 +14,17 @@ import (
 	"github.com/percona/everest/pkg/kubernetes"
 	"github.com/percona/everest/pkg/version"
 )
+
+const (
+	dbNamespaceSubChartPath = "/charts/everest-db-namespace"
+)
+
+func DBNamespaceSubChartPath(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	return path.Join(dir, dbNamespaceSubChartPath)
+}
 
 // CheckHelmInstallation ensures that the current installation was done using Helm chart.
 // Returns the version of Everest installed in the cluster.

--- a/pkg/cli/utils/utils.go
+++ b/pkg/cli/utils/utils.go
@@ -19,6 +19,7 @@ const (
 	dbNamespaceSubChartPath = "/charts/everest-db-namespace"
 )
 
+// DBNamespaceSubChartPath returns the path to the everest-db-namespace sub-chart.
 func DBNamespaceSubChartPath(dir string) string {
 	if dir == "" {
 		return ""


### PR DESCRIPTION
EVEREST-1673 

**Problem:**
Everest Feature builds use custom helm chart, so we need to specify the directory when using helm with FBs. Upgrade to a FB was working fine for the previous Everest version (when legacy migration mechanism was applied), however for non-legacy db namespaces upgrade we were still missing the support for custom directory.

**Solution**
This PR:
- adds the custom dir support for non-legacy db namespaces upgrades
- introduces a small refactoring to avoid code duplication