### PR TITLE
EVEREST-1819 [CLI] Get rid of spf13/viper lib for parsing CLI params

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -16,25 +16,15 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/go-logr/zapr"
-	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
-
 	"github.com/percona/everest/commands"
-	"github.com/percona/everest/pkg/logger"
 )
 
 func main() {
-	l := logger.MustInitLogger(false)
-
-	// This is required because controller-runtime requires a logger
-	// to be set within 30 seconds of the program initialization.
-	log := zapr.NewLogger(l)
-	ctrlruntimelog.SetLogger(log)
-
-	rootCmd := commands.NewRootCmd(l.Sugar())
-	if err := rootCmd.Execute(); err != nil {
+	if err := commands.Execute(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ const (
 )
 
 func main() {
-	logger := logger.MustInitLogger(true)
+	logger := logger.MustInitLogger(true, "everest")
 	defer logger.Sync() //nolint:errcheck
 	l := logger.Sugar()
 

--- a/commands/accounts.go
+++ b/commands/accounts.go
@@ -18,24 +18,25 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/commands/accounts"
 )
 
-func newAccountsCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "accounts",
-		Long:  "Manage Everest accounts",
-		Short: "Manage Everest accounts",
-	}
+var accountsCmd = &cobra.Command{
+	Use:   "accounts <command> [flags]",
+	Args:  cobra.ExactArgs(1),
+	Long:  "Manage Everest accounts",
+	Short: "Manage Everest accounts",
+	Run:   func(_ *cobra.Command, _ []string) {},
+}
 
-	cmd.AddCommand(accounts.NewCreateCmd(l))
-	cmd.AddCommand(accounts.NewListCmd(l))
-	cmd.AddCommand(accounts.NewDeleteCmd(l))
-	cmd.AddCommand(accounts.NewSetPwCommand(l))
-	cmd.AddCommand(accounts.NewResetJWTKeysCommand(l))
-	cmd.AddCommand(accounts.NewInitialAdminPasswdCommand(l))
+func init() {
+	rootCmd.AddCommand(accountsCmd)
 
-	return cmd
+	accountsCmd.AddCommand(accounts.GetCreateCmd())
+	accountsCmd.AddCommand(accounts.GetListCmd())
+	accountsCmd.AddCommand(accounts.GetDeleteCmd())
+	accountsCmd.AddCommand(accounts.GetSetPasswordCmd())
+	accountsCmd.AddCommand(accounts.GetResetJWTKeysCmd())
+	accountsCmd.AddCommand(accounts.GetInitAdminPasswordCmd())
 }

--- a/commands/accounts/delete.go
+++ b/commands/accounts/delete.go
@@ -17,61 +17,54 @@
 package accounts
 
 import (
-	"context"
-	"errors"
-	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	accountscli "github.com/percona/everest/pkg/accounts/cli"
-	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/cli"
+	"github.com/percona/everest/pkg/logger"
 )
 
-// NewDeleteCmd returns a new delete command.
-func NewDeleteCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "delete",
+var (
+	accountsDeleteCmd = &cobra.Command{
+		Use:     "delete [flags]",
+		Args:    cobra.NoArgs,
 		Example: "everestctl accounts delete --username user1",
 		Short:   "Delete an existing Everest user account",
 		Long:    "Delete an existing Everest user account",
-		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-			initDeleteViperFlags(cmd)
-
-			kubeconfigPath := viper.GetString("kubeconfig")
-			username := viper.GetString("username")
-
-			k, err := kubernetes.New(kubeconfigPath, l)
-			if err != nil {
-				var u *url.Error
-				if errors.As(err, &u) {
-					l.Error("Could not connect to Kubernetes. " +
-						"Make sure Kubernetes is running and is accessible from this computer/server.")
-				}
-				os.Exit(0)
-			}
-
-			cli := accountscli.New(l)
-			cli.WithAccountManager(k.Accounts())
-
-			if err := cli.Delete(context.Background(), username); err != nil {
-				l.Error(err)
-				os.Exit(1)
-			}
-		},
+		PreRun:  accountsDeletePreRun,
+		Run:     accountsDeleteRun,
 	}
-	initDeleteFlags(cmd)
-	return cmd
+	accountsDeleteCfg      = &accountscli.Config{}
+	accountsDeleteUsername string
+)
+
+func init() {
+	// local command flags
+	accountsDeleteCmd.Flags().StringVarP(&accountsDeleteUsername, cli.FlagAccountsUsername, "u", "", "Username of the account")
 }
 
-func initDeleteFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("username", "u", "", "Username of the account")
+func accountsDeletePreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	// Copy global flags to config
+	accountsDeleteCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	accountsDeleteCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 }
 
-func initDeleteViperFlags(cmd *cobra.Command) {
-	viper.BindPFlag("username", cmd.Flags().Lookup("username"))     //nolint:errcheck,gosec
-	viper.BindEnv("kubeconfig")                                     //nolint:errcheck,gosec
-	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
+func accountsDeleteRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cliA, err := accountscli.NewAccounts(*accountsDeleteCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+
+	if err := cliA.Delete(cmd.Context(), accountsDeleteUsername); err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+}
+
+// GetDeleteCmd returns the command to delete account.
+func GetDeleteCmd() *cobra.Command {
+	return accountsDeleteCmd
 }

--- a/commands/accounts/list.go
+++ b/commands/accounts/list.go
@@ -17,66 +17,60 @@
 package accounts
 
 import (
-	"context"
-	"errors"
-	"net/url"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	accountscli "github.com/percona/everest/pkg/accounts/cli"
-	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/cli"
+	"github.com/percona/everest/pkg/logger"
 )
 
-// NewListCmd returns a new list command.
-func NewListCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "list",
-		Example: "everestctl accounts list",
+var (
+	accountsListCmd = &cobra.Command{
+		Use:     "list [flags]",
+		Args:    cobra.NoArgs,
+		Example: "everestctl accounts list --no-headers",
 		Long:    "List all Everest user accounts",
 		Short:   "List all Everest user accounts",
-		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-			initListViperFlags(cmd)
-			o := &accountscli.ListOptions{}
-			err := viper.Unmarshal(o)
-			if err != nil {
-				os.Exit(1)
-			}
-			kubeconfigPath := viper.GetString("kubeconfig")
-
-			k, err := kubernetes.New(kubeconfigPath, l)
-			if err != nil {
-				var u *url.Error
-				if errors.As(err, &u) {
-					l.Error("Could not connect to Kubernetes. " +
-						"Make sure Kubernetes is running and is accessible from this computer/server.")
-				}
-				os.Exit(0)
-			}
-
-			cli := accountscli.New(l)
-			cli.WithAccountManager(k.Accounts())
-
-			if err := cli.List(context.Background(), o); err != nil {
-				l.Error(err)
-				os.Exit(1)
-			}
-		},
+		PreRun:  accountsListPreRun,
+		Run:     accountsListRun,
 	}
-	initListFlags(cmd)
-	return cmd
+	accountsListCfg  = &accountscli.Config{}
+	accountsListOpts = &accountscli.ListOptions{}
+)
+
+func init() {
+	// local command flags
+	accountsListCmd.Flags().BoolVar(&accountsListOpts.NoHeaders, "no-headers", false, "If set, hide table headers")
+	accountsListCmd.Flags().StringSliceVar(&accountsListOpts.Columns, "columns", nil,
+		fmt.Sprintf("Comma-separated list of column names to display. Supported columns: %s, %s, %s.",
+			accountscli.ColumnUser, accountscli.ColumnCapabilities, accountscli.ColumnEnabled,
+		),
+	)
 }
 
-func initListFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("no-headers", false, "If set, hide table headers")
-	cmd.Flags().StringSlice("columns", nil, "Comma-separated list of column names to display")
+func accountsListPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	// Copy global flags to config
+	accountsListCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	accountsListCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 }
 
-func initListViperFlags(cmd *cobra.Command) {
-	viper.BindEnv("kubeconfig")                                     //nolint:errcheck,gosec
-	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
-	viper.BindPFlag("no-headers", cmd.Flags().Lookup("no-headers")) //nolint:errcheck,gosec
-	viper.BindPFlag("columns", cmd.Flags().Lookup("columns"))       //nolint:errcheck,gosec
+func accountsListRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cliA, err := accountscli.NewAccounts(*accountsListCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+
+	if err := cliA.List(cmd.Context(), *accountsListOpts); err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+}
+
+// GetListCmd returns the command to list all user accounts.
+func GetListCmd() *cobra.Command {
+	return accountsListCmd
 }

--- a/commands/accounts/reset_jwt_keys.go
+++ b/commands/accounts/reset_jwt_keys.go
@@ -1,50 +1,64 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package accounts holds commands for accounts command.
 package accounts
 
 import (
-	"context"
-	"errors"
-	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
-	"github.com/percona/everest/pkg/kubernetes"
+	accountscli "github.com/percona/everest/pkg/accounts/cli"
+	"github.com/percona/everest/pkg/cli"
+	"github.com/percona/everest/pkg/logger"
 )
 
-// NewResetJWTKeysCommand returns a new reset-jwt-keys command.
-func NewResetJWTKeysCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "reset-jwt-keys",
+var (
+	accountsResetJWTKeysCmd = &cobra.Command{
+		Use:     "reset-jwt-keys [flags]",
+		Args:    cobra.NoArgs,
 		Example: "everestctl accounts reset-jwt-keys",
 		Long:    "Reset the JWT keys used for Everest user authentication",
 		Short:   "Reset the JWT keys used for Everest user authentication",
-		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-			viper.BindEnv("kubeconfig")                                     //nolint:errcheck,gosec
-			viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig")) //nolint:errcheck,gosec
-			kubeconfigPath := viper.GetString("kubeconfig")
-
-			k, err := kubernetes.New(kubeconfigPath, l)
-			if err != nil {
-				var u *url.Error
-				if errors.As(err, &u) {
-					l.Error("Could not connect to Kubernetes. " +
-						"Make sure Kubernetes is running and is accessible from this computer/server.")
-				}
-				os.Exit(1)
-			}
-
-			ctx := context.Background()
-			l.Info("Creating/Updating JWT keys and restarting Everest..")
-			if err := k.CreateRSAKeyPair(ctx); err != nil {
-				l.Error(err)
-				os.Exit(1)
-			}
-
-			l.Info("JWT keys created/updated successfully!")
-		},
+		PreRun:  accountsResetJWTKeysPreRun,
+		Run:     accountsResetJWTKeysRun,
 	}
-	return cmd
+	accountsResetJWTKeysCfg = &accountscli.Config{}
+)
+
+func accountsResetJWTKeysPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	// Copy global flags to config
+	accountsResetJWTKeysCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	accountsResetJWTKeysCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
+}
+
+func accountsResetJWTKeysRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cliA, err := accountscli.NewAccounts(*accountsResetJWTKeysCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+
+	if err := cliA.CreateRSAKeyPair(cmd.Context()); err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+}
+
+// GetResetJWTKeysCmd returns the command to reset the JWT keys used for Everest user authentication.
+func GetResetJWTKeysCmd() *cobra.Command {
+	return accountsResetJWTKeysCmd
 }

--- a/commands/accounts/set_password.go
+++ b/commands/accounts/set_password.go
@@ -1,67 +1,73 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package accounts holds commands for accounts command.
 //
 //nolint:dupl
 package accounts
 
 import (
-	"context"
-	"errors"
-	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	accountscli "github.com/percona/everest/pkg/accounts/cli"
-	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/cli"
+	"github.com/percona/everest/pkg/logger"
 )
 
-// NewSetPwCommand returns a new set-password command.
-func NewSetPwCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "set-password",
+var (
+	accountsSetPasswordCmd = &cobra.Command{
+		Use:     "set-password [flags]",
+		Args:    cobra.NoArgs,
 		Example: "everestctl accounts set-password --username user1 --new-password $USER_PASS",
 		Long:    "Set a new password for an existing Everest user account",
 		Short:   "Set a new password for an existing Everest user account",
-		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-			initSetPwViperFlags(cmd)
-
-			kubeconfigPath := viper.GetString("kubeconfig")
-			username := viper.GetString("username")
-			password := viper.GetString("new-password")
-
-			k, err := kubernetes.New(kubeconfigPath, l)
-			if err != nil {
-				var u *url.Error
-				if errors.As(err, &u) {
-					l.Error("Could not connect to Kubernetes. " +
-						"Make sure Kubernetes is running and is accessible from this computer/server.")
-				}
-				os.Exit(0)
-			}
-
-			cli := accountscli.New(l)
-			cli.WithAccountManager(k.Accounts())
-
-			if err := cli.SetPassword(context.Background(), username, password); err != nil {
-				l.Error(err)
-				os.Exit(1)
-			}
-		},
+		PreRun:  accountsSetPasswordPreRun,
+		Run:     accountsSetPasswordRun,
 	}
-	initSetPwFlags(cmd)
-	return cmd
+	accountsSetPasswordCfg  = &accountscli.Config{}
+	accountsSetPasswordOpts = &accountscli.SetPasswordOptions{}
+)
+
+func init() {
+	// local command flags
+	accountsSetPasswordCmd.Flags().StringVarP(&accountsSetPasswordOpts.Username, cli.FlagAccountsUsername, "u", "", "Username of the account")
+	accountsSetPasswordCmd.Flags().StringVarP(&accountsSetPasswordOpts.NewPassword, cli.FlagAccountsNewPassword, "p", "", "New password for the account")
 }
 
-func initSetPwFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("username", "u", "", "Username of the account")
-	cmd.Flags().StringP("new-password", "p", "", "New password for the account")
+func accountsSetPasswordPreRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	// Copy global flags to config
+	accountsSetPasswordCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	accountsSetPasswordCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 }
 
-func initSetPwViperFlags(cmd *cobra.Command) {
-	viper.BindPFlag("username", cmd.Flags().Lookup("username"))         //nolint:errcheck,gosec
-	viper.BindPFlag("new-password", cmd.Flags().Lookup("new-password")) //nolint:errcheck,gosec
-	viper.BindEnv("kubeconfig")                                         //nolint:errcheck,gosec
-	viper.BindPFlag("kubeconfig", cmd.Flags().Lookup("kubeconfig"))     //nolint:errcheck,gosec
+func accountsSetPasswordRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	cliA, err := accountscli.NewAccounts(*accountsSetPasswordCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+
+	if err := cliA.SetPassword(cmd.Context(), *accountsSetPasswordOpts); err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
+}
+
+// GetSetPasswordCmd returns the command to set password for an account.
+func GetSetPasswordCmd() *cobra.Command {
+	return accountsSetPasswordCmd
 }

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -18,19 +18,22 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/commands/namespaces"
 )
 
-func newNamespacesCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "namespaces",
-		Long:  "Managed Everest database namespaces",
-		Short: "Managed Everest database namespaces",
-	}
-	cmd.AddCommand(namespaces.NewAddCommand(l))
-	cmd.AddCommand(namespaces.NewRemoveCommand(l))
-	cmd.AddCommand(namespaces.NewUpdateCommand(l))
-	return cmd
+var namespacesCmd = &cobra.Command{
+	Use:   "namespaces <command> [flags]",
+	Args:  cobra.ExactArgs(1),
+	Long:  "Managed Everest database namespaces",
+	Short: "Managed Everest database namespaces",
+	Run:   func(_ *cobra.Command, _ []string) {},
+}
+
+func init() {
+	rootCmd.AddCommand(namespacesCmd)
+
+	namespacesCmd.AddCommand(namespaces.GetNamespacesAddCmd())
+	namespacesCmd.AddCommand(namespaces.GetNamespacesRemoveCmd())
+	namespacesCmd.AddCommand(namespaces.GetNamespacesUpdateCmd())
 }

--- a/commands/namespaces/add.go
+++ b/commands/namespaces/add.go
@@ -1,3 +1,18 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package namespaces provides the namespaces CLI command.
 package namespaces
 
@@ -7,12 +22,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/pkg/cli"
 	"github.com/percona/everest/pkg/cli/helm"
 	"github.com/percona/everest/pkg/cli/namespaces"
+	"github.com/percona/everest/pkg/logger"
 	"github.com/percona/everest/pkg/output"
 )
 
@@ -20,106 +34,72 @@ import (
 var (
 	takeOwnershipHintMessage = fmt.Sprintf("HINT: set '--%s' flag to use existing namespaces", cli.FlagTakeNamespaceOwnership)
 	updateHintMessage        = "HINT: use 'everestctl namespaces update' to update the namespace"
+	namespacesAddCmd         = &cobra.Command{
+		Use:     "add <namespaces> [flags]",
+		Args:    cobra.ExactArgs(1),
+		Long:    "Add a new namespace and make managed by Everest",
+		Short:   "Add a new namespace and make managed by Everest",
+		Example: `everestctl namespaces add ns-1,ns-2 --skip-wizard --operator.xtradb-cluster=true --operator.postgresql=false --operator.mongodb=false`,
+		PreRun:  namespacesAddPreRun,
+		Run:     namespacesAddRun,
+	}
+	namespacesAddCfg = &namespaces.NamespaceAddConfig{}
 )
 
-// NewAddCommand returns a new command to add a new namespace.
-func NewAddCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "add",
-		Long:    "Add a new namespace",
-		Short:   "Add a new namespace",
-		Example: `everestctl namespaces add [NAMESPACE] [FLAGS]`,
-		Run: func(cmd *cobra.Command, args []string) {
-			initAddViperFlags(cmd)
-			c := &namespaces.NamespaceAddConfig{}
-			err := viper.Unmarshal(c)
-			if err != nil {
-				l.Error(err)
-				return
-			}
-			bindInstallHelmOpts(c)
+func init() {
+	// local command flags
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.DisableTelemetry, cli.FlagDisableTelemetry, false, "Disable telemetry")
+	_ = namespacesAddCmd.Flags().MarkHidden(cli.FlagDisableTelemetry) //nolint:errcheck,gosec
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.SkipWizard, cli.FlagSkipWizard, false, "Skip installation wizard")
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.TakeOwnership, cli.FlagTakeNamespaceOwnership, false, "If the specified namespace already exists, take ownership of it")
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.SkipEnvDetection, cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
 
-			if len(args) != 1 {
-				output.PrintError(fmt.Errorf("invalid number of arguments: expected 1, got %d", len(args)), l, true)
-				os.Exit(1)
-			}
-			c.Namespaces = args[0]
+	// --helm.* flags
+	namespacesAddCmd.Flags().StringVar(&namespacesAddCfg.CLIOptions.ChartDir, helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
+	_ = namespacesAddCmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
+	namespacesAddCmd.Flags().StringVar(&namespacesAddCfg.CLIOptions.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
+	namespacesAddCmd.Flags().StringSliceVar(&namespacesAddCfg.CLIOptions.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
+	namespacesAddCmd.Flags().StringSliceVarP(&namespacesAddCfg.CLIOptions.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
 
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			c.Pretty = !enableLogging
+	// --operator.* flags
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.Operator.PSMDB, cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.Operator.PG, cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
+	namespacesAddCmd.Flags().BoolVar(&namespacesAddCfg.Operator.PXC, cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
+}
 
-			askOperators := !(cmd.Flags().Lookup("operator.mongodb").Changed ||
-				cmd.Flags().Lookup("operator.postgresql").Changed ||
-				cmd.Flags().Lookup("operator.xtradb-cluster").Changed)
+func namespacesAddPreRun(cmd *cobra.Command, args []string) { //nolint:revive
+	namespacesAddCfg.Namespaces = args[0]
 
-			if err := c.Populate(cmd.Context(), false, askOperators); err != nil {
-				if errors.Is(err, namespaces.ErrNamespaceAlreadyExists) {
-					err = fmt.Errorf("%w. %s", err, takeOwnershipHintMessage)
-				}
-				if errors.Is(err, namespaces.ErrNamespaceAlreadyOwned) {
-					err = fmt.Errorf("%w. %s", err, updateHintMessage)
-				}
-				output.PrintError(err, l, !enableLogging)
-				os.Exit(1)
-			}
+	// Copy global flags to config
+	namespacesAddCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	namespacesAddCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 
-			op, err := namespaces.NewNamespaceAdd(*c, l)
-			if err != nil {
-				output.PrintError(err, l, !enableLogging)
-				return
-			}
-			if err := op.Run(cmd.Context()); err != nil {
-				output.PrintError(err, l, !enableLogging)
-				os.Exit(1)
-			}
-		},
+	// If user doesn't pass any --operator.* flags - need to ask explicitly.
+	namespacesAddCfg.AskOperators = !(cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
+		cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
+		cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed)
+}
+
+func namespacesAddRun(cmd *cobra.Command, _ []string) {
+	op, err := namespaces.NewNamespaceAdd(*namespacesAddCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
 	}
-	initAddFlags(cmd)
-	return cmd
+
+	if err := op.Run(cmd.Context()); err != nil {
+		if errors.Is(err, namespaces.ErrNamespaceAlreadyExists) {
+			err = fmt.Errorf("%w. %s", err, takeOwnershipHintMessage)
+		}
+		if errors.Is(err, namespaces.ErrNamespaceAlreadyOwned) {
+			err = fmt.Errorf("%w. %s", err, updateHintMessage)
+		}
+		output.PrintError(err, logger.GetLogger(), namespacesAddCfg.Pretty)
+		os.Exit(1)
+	}
 }
 
-func initAddFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(cli.FlagDisableTelemetry, false, "Disable telemetry")
-	cmd.Flags().MarkHidden(cli.FlagDisableTelemetry) //nolint:errcheck,gosec
-	cmd.Flags().Bool(cli.FlagSkipWizard, false, "Skip installation wizard")
-	cmd.Flags().Bool(cli.FlagTakeNamespaceOwnership, false, "If the specified namespace already exists, take ownership of it")
-	cmd.Flags().Bool(cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
-
-	cmd.Flags().String(helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
-	cmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
-	cmd.Flags().String(helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
-	cmd.Flags().StringSlice(helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
-	cmd.Flags().StringSliceP(helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
-
-	cmd.Flags().Bool(cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
-	cmd.Flags().Bool(cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
-	cmd.Flags().Bool(cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
-}
-
-func initAddViperFlags(cmd *cobra.Command) {
-	viper.BindPFlag(cli.FlagSkipWizard, cmd.Flags().Lookup(cli.FlagSkipWizard))                         //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagDisableTelemetry, cmd.Flags().Lookup(cli.FlagDisableTelemetry))             //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagTakeNamespaceOwnership, cmd.Flags().Lookup(cli.FlagTakeNamespaceOwnership)) //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagSkipEnvDetection, cmd.Flags().Lookup(cli.FlagSkipEnvDetection))             //nolint:errcheck,gosec
-
-	viper.BindPFlag(helm.FlagChartDir, cmd.Flags().Lookup(helm.FlagChartDir))     //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagRepository, cmd.Flags().Lookup(helm.FlagRepository)) //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmSet, cmd.Flags().Lookup(helm.FlagHelmSet))       //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmValues, cmd.Flags().Lookup(helm.FlagHelmValues)) //nolint:errcheck,gosec
-
-	viper.BindPFlag(cli.FlagOperatorMongoDB, cmd.Flags().Lookup("operator.mongodb"))              //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagOperatorPostgresql, cmd.Flags().Lookup("operator.postgresql"))        //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagOperatorXtraDBCluster, cmd.Flags().Lookup("operator.xtradb-cluster")) //nolint:errcheck,gosec
-
-	viper.BindEnv(cli.FlagKubeconfig)                                           //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagKubeconfig, cmd.Flags().Lookup(cli.FlagKubeconfig)) //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagVerbose, cmd.Flags().Lookup(cli.FlagVerbose))       //nolint:errcheck,gosec
-	viper.BindPFlag("json", cmd.Flags().Lookup("json"))                         //nolint:errcheck,gosec
-}
-
-func bindInstallHelmOpts(cfg *namespaces.NamespaceAddConfig) {
-	cfg.CLIOptions.Values.Values = viper.GetStringSlice(helm.FlagHelmSet)
-	cfg.CLIOptions.Values.ValueFiles = viper.GetStringSlice(helm.FlagHelmValues)
-	cfg.CLIOptions.ChartDir = viper.GetString(helm.FlagChartDir)
-	cfg.CLIOptions.RepoURL = viper.GetString(helm.FlagRepository)
+// GetNamespacesAddCmd returns the command to add namespaces.
+func GetNamespacesAddCmd() *cobra.Command {
+	return namespacesAddCmd
 }

--- a/commands/namespaces/remove.go
+++ b/commands/namespaces/remove.go
@@ -1,3 +1,18 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package namespaces provides the namespaces CLI command.
 package namespaces
 
@@ -7,73 +22,59 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/pkg/cli"
 	"github.com/percona/everest/pkg/cli/namespaces"
+	"github.com/percona/everest/pkg/logger"
 	"github.com/percona/everest/pkg/output"
 )
 
 const forceUninstallHint = "HINT: use --force to remove the namespace and all its resources"
 
-// NewRemoveCommand returns a new command to remove an existing namespace.
-func NewRemoveCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "remove",
+var (
+	namespacesRemoveCmd = &cobra.Command{
+		Use:     "remove <namespaces> [flags]",
+		Args:    cobra.ExactArgs(1),
 		Long:    "Remove an existing namespace",
 		Short:   "Remove an existing namespace",
-		Example: `everestctl namespaces remove [NAMESPACE] [FLAGS]`,
-		Run: func(cmd *cobra.Command, args []string) {
-			initRemoveViperFlags(cmd)
-			c := &namespaces.NamespaceRemoveConfig{}
-			err := viper.Unmarshal(c)
-			if err != nil {
-				l.Error(err)
-				return
-			}
-
-			if len(args) != 1 {
-				output.PrintError(fmt.Errorf("invalid number of arguments: expected 1, got %d", len(args)), l, true)
-				os.Exit(1)
-			}
-
-			namespace := args[0]
-			c.Namespaces = []string{namespace}
-
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			c.Pretty = !enableLogging
-
-			op, err := namespaces.NewNamespaceRemove(*c, l)
-			if err != nil {
-				output.PrintError(err, l, !enableLogging)
-				return
-			}
-
-			if err := op.Run(cmd.Context()); err != nil {
-				if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
-					err = fmt.Errorf("%w. %s", err, forceUninstallHint)
-				}
-				output.PrintError(err, l, !enableLogging)
-				os.Exit(1)
-			}
-		},
+		Example: `everestctl namespaces remove ns-1,ns-2 --keep-namespace`,
+		PreRun:  namespacesRemovePreRun,
+		Run:     namespacesRemoveRun,
 	}
-	initRemoveFlags(cmd)
-	return cmd
+	namespacesRemoveCfg = &namespaces.NamespaceRemoveConfig{}
+)
+
+func init() {
+	// local command flags
+	namespacesRemoveCmd.Flags().BoolVar(&namespacesRemoveCfg.KeepNamespace, cli.FlagKeepNamespace, false, "If set, preserves the Kubernetes namespace but removes all resources managed by Everest")
+	namespacesRemoveCmd.Flags().BoolVar(&namespacesRemoveCfg.Force, cli.FlagNamespaceForce, false, "If set, forcefully deletes database clusters in the namespace (if any)")
 }
 
-func initRemoveFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("keep-namespace", false, "If set, preserves the Kubernetes namespace but removes all resources managed by Everest")
-	cmd.Flags().Bool("force", false, "If set, forcefully deletes database clusters in the namespace (if any)")
+func namespacesRemovePreRun(cmd *cobra.Command, args []string) { //nolint:revive
+	namespacesRemoveCfg.Namespaces = args[0]
+
+	// Copy global flags to config
+	namespacesRemoveCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	namespacesRemoveCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 }
 
-func initRemoveViperFlags(cmd *cobra.Command) {
-	viper.BindPFlag("keep-namespace", cmd.Flags().Lookup("keep-namespace")) //nolint:errcheck,gosec
-	viper.BindPFlag("force", cmd.Flags().Lookup("force"))                   //nolint:errcheck,gosec
+func namespacesRemoveRun(cmd *cobra.Command, _ []string) {
+	op, err := namespaces.NewNamespaceRemove(*namespacesRemoveCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
 
-	viper.BindEnv(cli.FlagKubeconfig)                                           //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagKubeconfig, cmd.Flags().Lookup(cli.FlagKubeconfig)) //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagVerbose, cmd.Flags().Lookup(cli.FlagVerbose))       //nolint:errcheck,gosec
-	viper.BindPFlag("json", cmd.Flags().Lookup("json"))                         //nolint:errcheck,gosec
+	if err := op.Run(cmd.Context()); err != nil {
+		if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
+			err = fmt.Errorf("%w. %s", err, forceUninstallHint)
+		}
+		output.PrintError(err, logger.GetLogger(), namespacesRemoveCfg.Pretty)
+		os.Exit(1)
+	}
+}
+
+// GetNamespacesRemoveCmd returns the command to remove a namespaces.
+func GetNamespacesRemoveCmd() *cobra.Command {
+	return namespacesRemoveCmd
 }

--- a/commands/namespaces/update.go
+++ b/commands/namespaces/update.go
@@ -17,88 +17,88 @@
 package namespaces
 
 import (
-    "errors"
-    "fmt"
-    "os"
+	"errors"
+	"fmt"
+	"os"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 
-    "github.com/percona/everest/pkg/cli"
-    "github.com/percona/everest/pkg/cli/helm"
-    "github.com/percona/everest/pkg/cli/namespaces"
-    "github.com/percona/everest/pkg/logger"
-    "github.com/percona/everest/pkg/output"
+	"github.com/percona/everest/pkg/cli"
+	"github.com/percona/everest/pkg/cli/helm"
+	"github.com/percona/everest/pkg/cli/namespaces"
+	"github.com/percona/everest/pkg/logger"
+	"github.com/percona/everest/pkg/output"
 )
 
 var (
-    namespacesUpdateCmd = &cobra.Command{
-        Use:     "update <namespaces> [flags] ",
-        Args:    cobra.ExactArgs(1),
-        Long:    "Add database operator to existing namespace managed by Everest",
-        Short:   "Add database operator to existing namespace managed by Everest",
-        Example: `everestctl namespaces update ns-1,ns-2 --skip-wizard --operator.xtradb-cluster=true --operator.postgresql=false --operator.mongodb=false`,
-        PreRun:  namespacesUpdatePreRun,
-        Run:     namespacesUpdateRun,
-    }
-    namespacesUpdateCfg = &namespaces.NamespaceAddConfig{}
+	namespacesUpdateCmd = &cobra.Command{
+		Use:     "update <namespaces> [flags] ",
+		Args:    cobra.ExactArgs(1),
+		Long:    "Add database operator to existing namespace managed by Everest",
+		Short:   "Add database operator to existing namespace managed by Everest",
+		Example: `everestctl namespaces update ns-1,ns-2 --skip-wizard --operator.xtradb-cluster=true --operator.postgresql=false --operator.mongodb=false`,
+		PreRun:  namespacesUpdatePreRun,
+		Run:     namespacesUpdateRun,
+	}
+	namespacesUpdateCfg = &namespaces.NamespaceAddConfig{}
 )
 
 func init() {
-    // local command flags
-    namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.DisableTelemetry, cli.FlagDisableTelemetry, false, "Disable telemetry")
-    _ = namespacesUpdateCmd.Flags().MarkHidden(cli.FlagDisableTelemetry) //nolint:errcheck,gosec
-    namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.SkipWizard, cli.FlagSkipWizard, false, "Skip installation wizard")
-    namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.SkipEnvDetection, cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
+	// local command flags
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.DisableTelemetry, cli.FlagDisableTelemetry, false, "Disable telemetry")
+	_ = namespacesUpdateCmd.Flags().MarkHidden(cli.FlagDisableTelemetry) //nolint:errcheck,gosec
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.SkipWizard, cli.FlagSkipWizard, false, "Skip installation wizard")
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.SkipEnvDetection, cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
 
-    // --helm.* flags
-    namespacesUpdateCmd.Flags().StringVar(&namespacesUpdateCfg.CLIOptions.ChartDir, helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
-    _ = namespacesUpdateCmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
-    namespacesUpdateCmd.Flags().StringVar(&namespacesUpdateCfg.CLIOptions.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
-    namespacesUpdateCmd.Flags().StringSliceVar(&namespacesUpdateCfg.CLIOptions.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
-    namespacesUpdateCmd.Flags().StringSliceVarP(&namespacesUpdateCfg.CLIOptions.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
+	// --helm.* flags
+	namespacesUpdateCmd.Flags().StringVar(&namespacesUpdateCfg.CLIOptions.ChartDir, helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
+	_ = namespacesUpdateCmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
+	namespacesUpdateCmd.Flags().StringVar(&namespacesUpdateCfg.CLIOptions.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
+	namespacesUpdateCmd.Flags().StringSliceVar(&namespacesUpdateCfg.CLIOptions.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
+	namespacesUpdateCmd.Flags().StringSliceVarP(&namespacesUpdateCfg.CLIOptions.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
 
-    // --operator.* flags
-    namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PSMDB, cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
-    namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PG, cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
-    namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PXC, cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
+	// --operator.* flags
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PSMDB, cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PG, cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PXC, cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
 }
 
 func namespacesUpdatePreRun(cmd *cobra.Command, args []string) { //nolint:revive
-    namespacesUpdateCfg.Namespaces = args[0]
-    namespacesUpdateCfg.Update = true
+	namespacesUpdateCfg.Namespaces = args[0]
+	namespacesUpdateCfg.Update = true
 
-    // Copy global flags to config
-    namespacesUpdateCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
-    namespacesUpdateCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
+	// Copy global flags to config
+	namespacesUpdateCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	namespacesUpdateCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 
-    // If user doesn't pass any --operator.* flags - need to ask explicitly.
-    namespacesUpdateCfg.AskOperators = !(cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
-        cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
-        cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed)
+	// If user doesn't pass any --operator.* flags - need to ask explicitly.
+	namespacesUpdateCfg.AskOperators = !(cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
+		cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
+		cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed)
 }
 
 func namespacesUpdateRun(cmd *cobra.Command, _ []string) {
-    op, err := namespaces.NewNamespaceAdd(*namespacesUpdateCfg, logger.GetLogger())
-    if err != nil {
-        logger.GetLogger().Error(err)
-        os.Exit(1)
-    }
+	op, err := namespaces.NewNamespaceAdd(*namespacesUpdateCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
 
-    if err := op.Run(cmd.Context()); err != nil {
-        if errors.Is(err, namespaces.ErrNamespaceNotManagedByEverest) {
-            err = fmt.Errorf("%w. HINT: use 'everestctl namespaces add --%s %s' first to make namespace managed by Everest",
-                err,
-                cli.FlagTakeNamespaceOwnership,
-                namespacesUpdateCfg.Namespaces,
-            )
-        }
+	if err := op.Run(cmd.Context()); err != nil {
+		if errors.Is(err, namespaces.ErrNamespaceNotManagedByEverest) {
+			err = fmt.Errorf("%w. HINT: use 'everestctl namespaces add --%s %s' first to make namespace managed by Everest",
+				err,
+				cli.FlagTakeNamespaceOwnership,
+				namespacesUpdateCfg.Namespaces,
+			)
+		}
 
-        output.PrintError(err, logger.GetLogger(), namespacesAddCfg.Pretty)
-        os.Exit(1)
-    }
+		output.PrintError(err, logger.GetLogger(), namespacesAddCfg.Pretty)
+		os.Exit(1)
+	}
 }
 
 // GetNamespacesUpdateCmd returns the command to update namespaces.
 func GetNamespacesUpdateCmd() *cobra.Command {
-    return namespacesUpdateCmd
+	return namespacesUpdateCmd
 }

--- a/commands/namespaces/update.go
+++ b/commands/namespaces/update.go
@@ -1,102 +1,94 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package namespaces provides the namespaces CLI command.
 package namespaces
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/pkg/cli"
 	"github.com/percona/everest/pkg/cli/helm"
 	"github.com/percona/everest/pkg/cli/namespaces"
+	"github.com/percona/everest/pkg/logger"
 	"github.com/percona/everest/pkg/output"
 )
 
-// NewUpdateCommand returns a new command to update an existing namespace.
-func NewUpdateCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "update",
-		Long:    "Update an existing Everest namespace",
-		Short:   "Update an existing Everest namespace",
-		Example: `everestctl update add [NAMESPACE] [FLAGS]`,
-		Run: func(cmd *cobra.Command, args []string) {
-			initUpdateViperFlags(cmd)
-			c := &namespaces.NamespaceAddConfig{}
-			err := viper.Unmarshal(c)
-			if err != nil {
-				l.Error(err)
-				return
-			}
-			bindInstallHelmOpts(c)
-			c.Update = true
-
-			if len(args) != 1 {
-				output.PrintError(fmt.Errorf("invalid number of arguments: expected 1, got %d", len(args)), l, true)
-				os.Exit(1)
-			}
-			c.Namespaces = args[0]
-
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			c.Pretty = !enableLogging
-
-			askOperators := !(cmd.Flags().Lookup("operator.mongodb").Changed ||
-				cmd.Flags().Lookup("operator.postgresql").Changed ||
-				cmd.Flags().Lookup("operator.xtradb-cluster").Changed)
-
-			if err := c.Populate(cmd.Context(), false, askOperators); err != nil {
-				output.PrintError(err, l, !enableLogging)
-				os.Exit(1)
-			}
-
-			op, err := namespaces.NewNamespaceAdd(*c, l)
-			if err != nil {
-				output.PrintError(err, l, !enableLogging)
-				return
-			}
-			if err := op.Run(cmd.Context()); err != nil {
-				output.PrintError(err, l, !enableLogging)
-				os.Exit(1)
-			}
-		},
+var (
+	namespacesUpdateCmd = &cobra.Command{
+		Use:     "update <namespaces> [flags] ",
+		Args:    cobra.ExactArgs(1),
+		Long:    "Make an existing namespaces managed by Everest",
+		Short:   "Make an existing namespaces managed by Everest",
+		Example: `everestctl namespaces update ns-1,ns-2 --skip-wizard --operator.xtradb-cluster=true --operator.postgresql=false --operator.mongodb=false`,
+		PreRun:  namespacesUpdatePreRun,
+		Run:     namespacesUpdateRun,
 	}
-	initUpdateFlags(cmd)
-	return cmd
+	namespacesUpdateCfg = &namespaces.NamespaceAddConfig{}
+)
+
+func init() {
+	// local command flags
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.DisableTelemetry, cli.FlagDisableTelemetry, false, "Disable telemetry")
+	_ = namespacesUpdateCmd.Flags().MarkHidden(cli.FlagDisableTelemetry) //nolint:errcheck,gosec
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.SkipWizard, cli.FlagSkipWizard, false, "Skip installation wizard")
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.SkipEnvDetection, cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
+
+	// --helm.* flags
+	namespacesUpdateCmd.Flags().StringVar(&namespacesUpdateCfg.CLIOptions.ChartDir, helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
+	_ = namespacesUpdateCmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
+	namespacesUpdateCmd.Flags().StringVar(&namespacesUpdateCfg.CLIOptions.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
+	namespacesUpdateCmd.Flags().StringSliceVar(&namespacesUpdateCfg.CLIOptions.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
+	namespacesUpdateCmd.Flags().StringSliceVarP(&namespacesUpdateCfg.CLIOptions.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
+
+	// --operator.* flags
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PSMDB, cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PG, cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
+	namespacesUpdateCmd.Flags().BoolVar(&namespacesUpdateCfg.Operator.PXC, cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
 }
 
-func initUpdateFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(cli.FlagDisableTelemetry, false, "Disable telemetry")
-	cmd.Flags().MarkHidden(cli.FlagDisableTelemetry) //nolint:errcheck,gosec
-	cmd.Flags().Bool(cli.FlagSkipWizard, false, "Skip installation wizard")
+func namespacesUpdatePreRun(cmd *cobra.Command, args []string) { //nolint:revive
+	namespacesUpdateCfg.Namespaces = args[0]
+	namespacesUpdateCfg.Update = true
 
-	cmd.Flags().String(helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
-	cmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
-	cmd.Flags().String(helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
-	cmd.Flags().StringSlice(helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
-	cmd.Flags().StringSliceP(helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
+	// Copy global flags to config
+	namespacesUpdateCfg.Pretty = !(cmd.Flag(cli.FlagVerbose).Changed || cmd.Flag(cli.FlagJSON).Changed)
+	namespacesUpdateCfg.KubeconfigPath = cmd.Flag(cli.FlagKubeconfig).Value.String()
 
-	cmd.Flags().Bool(cli.FlagOperatorMongoDB, true, "Install MongoDB operator")
-	cmd.Flags().Bool(cli.FlagOperatorPostgresql, true, "Install PostgreSQL operator")
-	cmd.Flags().Bool(cli.FlagOperatorXtraDBCluster, true, "Install XtraDB Cluster operator")
+	// If user doesn't pass any --operator.* flags - need to ask explicitly.
+	namespacesUpdateCfg.AskOperators = !(cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
+		cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
+		cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed)
 }
 
-func initUpdateViperFlags(cmd *cobra.Command) {
-	viper.BindPFlag(cli.FlagSkipWizard, cmd.Flags().Lookup(cli.FlagSkipWizard))             //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagDisableTelemetry, cmd.Flags().Lookup(cli.FlagDisableTelemetry)) //nolint:errcheck,gosec
+func namespacesUpdateRun(cmd *cobra.Command, _ []string) {
+	op, err := namespaces.NewNamespaceAdd(*namespacesUpdateCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
 
-	viper.BindPFlag(helm.FlagChartDir, cmd.Flags().Lookup(helm.FlagChartDir))     //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagRepository, cmd.Flags().Lookup(helm.FlagRepository)) //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmSet, cmd.Flags().Lookup(helm.FlagHelmSet))       //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmValues, cmd.Flags().Lookup(helm.FlagHelmValues)) //nolint:errcheck,gosec
+	if err := op.Run(cmd.Context()); err != nil {
+		output.PrintError(err, logger.GetLogger(), namespacesAddCfg.Pretty)
+		os.Exit(1)
+	}
+}
 
-	viper.BindPFlag(cli.FlagOperatorMongoDB, cmd.Flags().Lookup("operator.mongodb"))              //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagOperatorPostgresql, cmd.Flags().Lookup("operator.postgresql"))        //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagOperatorXtraDBCluster, cmd.Flags().Lookup("operator.xtradb-cluster")) //nolint:errcheck,gosec
-
-	viper.BindEnv(cli.FlagKubeconfig)                                           //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagKubeconfig, cmd.Flags().Lookup(cli.FlagKubeconfig)) //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagVerbose, cmd.Flags().Lookup(cli.FlagVerbose))       //nolint:errcheck,gosec
-	viper.BindPFlag("json", cmd.Flags().Lookup("json"))                         //nolint:errcheck,gosec
+// GetNamespacesUpdateCmd returns the command to update namespaces.
+func GetNamespacesUpdateCmd() *cobra.Command {
+	return namespacesUpdateCmd
 }

--- a/commands/settings.go
+++ b/commands/settings.go
@@ -18,18 +18,21 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/commands/settings"
 )
 
-func newSettingsCommand(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "settings",
-		Long:  "Configure Everest settings",
-		Short: "Configure Everest settings",
-	}
-	cmd.AddCommand(settings.NewOIDCCmd(l))
-	cmd.AddCommand(settings.NewRBACCmd(l))
-	return cmd
+var settingsCmd = &cobra.Command{
+	Use:   "settings <command> [flags]",
+	Args:  cobra.ExactArgs(1),
+	Long:  "Configure Everest settings",
+	Short: "Configure Everest settings",
+	Run:   func(_ *cobra.Command, _ []string) {},
+}
+
+func init() {
+	rootCmd.AddCommand(settingsCmd)
+
+	settingsCmd.AddCommand(settings.GetSettingsOIDCCmd())
+	settingsCmd.AddCommand(settings.GetSettingsRBACCmd())
 }

--- a/commands/settings/oidc.go
+++ b/commands/settings/oidc.go
@@ -13,25 +13,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package settings ...
+// Package settings provides the Everest settings CLI commands.
 package settings
 
 import (
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/commands/settings/oidc"
 )
 
-// NewOIDCCmd returns an new OIDC sub-command.
-func NewOIDCCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "oidc",
-		Long:  "Manage settings related to OIDC",
-		Short: "Manage settings related to OIDC",
-	}
+var settingsOIDCCmd = &cobra.Command{
+	Use:   "oidc <command> [flags]",
+	Args:  cobra.ExactArgs(1),
+	Long:  "Manage settings related to OIDC",
+	Short: "Manage settings related to OIDC",
+}
 
-	cmd.AddCommand(oidc.NewConfigureCommand(l))
+func init() {
+	settingsOIDCCmd.AddCommand(oidc.GetSettingsOIDCConfigureCmd())
+}
 
-	return cmd
+// GetSettingsOIDCCmd returns the command to manage OIDC settings.
+func GetSettingsOIDCCmd() *cobra.Command {
+	return settingsOIDCCmd
 }

--- a/commands/settings/rbac.go
+++ b/commands/settings/rbac.go
@@ -1,21 +1,40 @@
-// Package settings ...
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package settings provides the Everest settings CLI commands.
 package settings
 
 import (
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/commands/settings/rbac"
 )
 
-// NewRBACCmd returns an new RBAC sub-command.
-func NewRBACCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "rbac",
-		Long:  "Manage RBAC settings",
-		Short: "Manage RBAC settings",
-	}
-	cmd.AddCommand(rbac.NewValidateCommand(l))
-	cmd.AddCommand(rbac.NewCanCommand(l))
-	return cmd
+var settingsRBACCmd = &cobra.Command{
+	Use:   "rbac <command> [flags]",
+	Args:  cobra.ExactArgs(1),
+	Long:  "Manage RBAC settings",
+	Short: "Manage RBAC settings",
+}
+
+func init() {
+	settingsRBACCmd.AddCommand(rbac.GetSettingsRBACValidateCmd())
+	settingsRBACCmd.AddCommand(rbac.GetSettingsRBACCanCmd())
+}
+
+// GetSettingsRBACCmd returns the command to manage RBAC settings.
+func GetSettingsRBACCmd() *cobra.Command {
+	return settingsRBACCmd
 }

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -20,96 +20,63 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	"github.com/percona/everest/pkg/cli"
 	"github.com/percona/everest/pkg/cli/helm"
 	"github.com/percona/everest/pkg/cli/upgrade"
+	"github.com/percona/everest/pkg/logger"
 	"github.com/percona/everest/pkg/output"
 )
 
-func newUpgradeCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use: "upgrade",
-		// The command expects no arguments. So to prevent users from misspelling and confusion
-		// in cases with unexpected spaces like
-		//       ./everestctl upgrade --namespaces=aaa, a
-		// it will return
-		//        Error: unknown command "a" for "everestctl upgrade"
-		Args:  cobra.NoArgs,
-		Long:  "Upgrade Percona Everest using Helm",
-		Short: "Upgrade Percona Everest using Helm",
-		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-			initUpgradeViperFlags(cmd)
-
-			c, err := parseUpgradeConfig()
-			if err != nil {
-				os.Exit(1)
-			}
-			c.CLIOptions.BindViperFlags()
-
-			enableLogging := viper.GetBool("verbose") || viper.GetBool("json")
-			c.Pretty = !enableLogging
-
-			op, err := upgrade.NewUpgrade(c, l)
-			if err != nil {
-				l.Error(err)
-				os.Exit(1)
-			}
-
-			if err := op.Run(cmd.Context()); err != nil {
-				output.PrintError(err, l, !enableLogging)
-				os.Exit(1)
-			}
-		},
+var (
+	upgradeCmd = &cobra.Command{
+		Use:    "upgrade [flags]",
+		Args:   cobra.NoArgs,
+		Long:   "Upgrade Percona Everest using Helm",
+		Short:  "Upgrade Percona Everest using Helm",
+		PreRun: upgradePreRun,
+		Run:    upgradeRun,
 	}
 
-	initUpgradeFlags(cmd)
+	upgradeCfg = &upgrade.Config{}
+)
 
-	return cmd
+func init() {
+	rootCmd.AddCommand(upgradeCmd)
+
+	// local command flags
+	upgradeCmd.Flags().StringVar(&upgradeCfg.VersionMetadataURL, cli.FlagVersionMetadataURL, "https://check.percona.com", "URL to retrieve version metadata information from")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.SkipEnvDetection, cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.DryRun, cli.FlagUpgradeDryRun, false, "If set, only executes the pre-upgrade checks")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.InCluster, cli.FlagUpgradeInCluster, false, "If set, uses the in-cluster Kubernetes client configuration")
+	_ = upgradeCmd.Flags().MarkHidden(cli.FlagUpgradeInCluster)
+
+	// --helm.* flags
+	upgradeCmd.Flags().StringVar(&upgradeCfg.ChartDir, helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
+	_ = upgradeCmd.Flags().MarkHidden(helm.FlagChartDir)
+	upgradeCmd.Flags().StringVar(&upgradeCfg.RepoURL, helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
+	upgradeCmd.Flags().StringSliceVar(&upgradeCfg.Values.Values, helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
+	upgradeCmd.Flags().StringSliceVarP(&upgradeCfg.Values.ValueFiles, helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetValues, helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
+	upgradeCmd.Flags().BoolVar(&upgradeCfg.ResetThenReuseValues, helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
 }
 
-func initUpgradeFlags(cmd *cobra.Command) {
-	cmd.Flags().String(cli.FlagVersionMetadataURL, "https://check.percona.com", "URL to retrieve version metadata information from")
-	cmd.Flags().Bool(cli.FlagSkipEnvDetection, false, "Skip detecting Kubernetes environment where Everest is installed")
-
-	cmd.Flags().String(helm.FlagChartDir, "", "Path to the chart directory. If not set, the chart will be downloaded from the repository")
-	cmd.Flags().MarkHidden(helm.FlagChartDir) //nolint:errcheck,gosec
-	cmd.Flags().String(helm.FlagRepository, helm.DefaultHelmRepoURL, "Helm chart repository to download the Everest charts from")
-	cmd.Flags().StringSlice(helm.FlagHelmSet, []string{}, "Set helm values on the command line (can specify multiple values with commas: key1=val1,key2=val2)")
-	cmd.Flags().StringSliceP(helm.FlagHelmValues, "f", []string{}, "Specify values in a YAML file or a URL (can specify multiple)")
-	cmd.Flags().Bool(helm.FlagHelmReuseValues, false, "Reuse the last release's values and merge in any overrides from the command line via --helm.set and -f")
-	cmd.Flags().Bool(helm.FlagHelmResetValues, false, "Reset the values to the ones built into the chart")
-	cmd.Flags().Bool(helm.FlagHelmResetThenReuseValues, false, "Reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.")
-
-	cmd.Flags().BoolP("logs", "l", false, "If set, logs are printed during the upgrade process")
-	cmd.Flags().Bool("dry-run", false, "If set, only executes the pre-upgrade checks")
-	cmd.Flags().Bool("in-cluster", false, "If set, uses the in-cluster Kubernetes client configuration")
+func upgradePreRun(_ *cobra.Command, _ []string) { //nolint:revive
+	// Copy global flags to config
+	upgradeCfg.Pretty = rootCmdFlags.Pretty
+	upgradeCfg.KubeconfigPath = rootCmdFlags.KubeconfigPath
 }
 
-func initUpgradeViperFlags(cmd *cobra.Command) {
-	viper.BindEnv(cli.FlagKubeconfig)                                                           //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagKubeconfig, cmd.Flags().Lookup(cli.FlagKubeconfig))                 //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagVersionMetadataURL, cmd.Flags().Lookup(cli.FlagVersionMetadataURL)) //nolint:errcheck,gosec
-	viper.BindPFlag(cli.FlagVerbose, cmd.Flags().Lookup(cli.FlagVerbose))                       //nolint:errcheck,gosec
-	viper.BindPFlag("json", cmd.Flags().Lookup("json"))                                         //nolint:errcheck,gosec
-	viper.BindPFlag("dry-run", cmd.Flags().Lookup("dry-run"))                                   //nolint:errcheck,gosec
-	viper.BindPFlag("in-cluster", cmd.Flags().Lookup("in-cluster"))                             //nolint:errcheck,gosec
+func upgradeRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	op, err := upgrade.NewUpgrade(upgradeCfg, logger.GetLogger())
+	if err != nil {
+		logger.GetLogger().Error(err)
+		os.Exit(1)
+	}
 
-	viper.BindPFlag(upgrade.FlagSkipEnvDetection, cmd.Flags().Lookup(upgrade.FlagSkipEnvDetection)) //nolint:errcheck,gosec
-
-	viper.BindPFlag(helm.FlagChartDir, cmd.Flags().Lookup(helm.FlagChartDir))                                 //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagRepository, cmd.Flags().Lookup(helm.FlagRepository))                             //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmSet, cmd.Flags().Lookup(helm.FlagHelmSet))                                   //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmValues, cmd.Flags().Lookup(helm.FlagHelmValues))                             //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmReuseValues, cmd.Flags().Lookup(helm.FlagHelmReuseValues))                   //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmResetValues, cmd.Flags().Lookup(helm.FlagHelmResetValues))                   //nolint:errcheck,gosec
-	viper.BindPFlag(helm.FlagHelmResetThenReuseValues, cmd.Flags().Lookup(helm.FlagHelmResetThenReuseValues)) //nolint:errcheck,gosec
-}
-
-func parseUpgradeConfig() (*upgrade.Config, error) {
-	c := &upgrade.Config{}
-	err := viper.Unmarshal(c)
-	return c, err
+	if err := op.Run(cmd.Context()); err != nil {
+		output.PrintError(err, logger.GetLogger(), upgradeCfg.Pretty)
+		os.Exit(1)
+	}
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,3 +1,18 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (
@@ -5,75 +20,63 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/percona/everest/pkg/cli/utils"
+	"github.com/percona/everest/pkg/logger"
 	"github.com/percona/everest/pkg/version"
 )
 
-func newVersionCmd(l *zap.SugaredLogger) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "version",
-		Long:  "Print version info",
-		Short: "Print version info",
-		Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-			outputJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				l.Errorf("could not parse json global flag. Error: %s", err)
-				os.Exit(1)
-				return
-			}
-			kubeConfigPath, err := cmd.Flags().GetString("kubeconfig")
-			if err != nil {
-				l.Errorf("could not parse kubeconfig global flag. Error: %s", err)
-				os.Exit(1)
-				return
-			}
-
-			clientOnly, err := cmd.Flags().GetBool("client-only")
-			if err != nil {
-				l.Errorf("could not parse client-only flag. Error: %s", err)
-				os.Exit(1)
-				return
-			}
-
-			v := version.Info{
-				ProjectName: version.ProjectName,
-				Version:     version.Version,
-				FullCommit:  version.FullCommit,
-			}
-
-			if !clientOnly {
-				var err error
-				k, err := utils.NewKubeclient(l, kubeConfigPath)
-				if err != nil {
-					os.Exit(1)
-					return
-				}
-				ev, err := version.EverestVersionFromDeployment(cmd.Context(), k)
-				if client.IgnoreNotFound(err) != nil {
-					l.Error(err)
-					os.Exit(1)
-				}
-				sv := "[NOT INSTALLED]"
-				if ev != nil {
-					sv = fmt.Sprintf("v%s", ev.String())
-				}
-				v.ServerVersion = &sv
-			}
-
-			if !outputJSON {
-				fmt.Fprintln(os.Stdout, v)
-				return
-			}
-			fmt.Fprintln(os.Stdout, v.JSONString())
-		},
+var (
+	versionCmd = &cobra.Command{
+		Use:   "version [flags]",
+		Args:  cobra.NoArgs,
+		Long:  "Print Everest components version info",
+		Short: "Print Everest components version info",
+		RunE:  versionRunE,
 	}
-	initVersionFlags(cmd)
-	return cmd
+
+	// Command flag values
+	clientOnlyFlag bool // Means only info about the client shall be printed
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// local command flags
+	versionCmd.Flags().BoolVar(&clientOnlyFlag, "client-only", false, "Print client version only")
 }
 
-func initVersionFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("client-only", false, "Print client version only")
+func versionRunE(cmd *cobra.Command, _ []string) error { //nolint:revive
+	v := version.Info{
+		ProjectName: version.ProjectName,
+		Version:     version.Version,
+		FullCommit:  version.FullCommit,
+	}
+	cmdLogger := logger.GetLogger().With("component", "version")
+
+	if !clientOnlyFlag {
+		k, err := utils.NewKubeclient(cmdLogger, rootCmdFlags.KubeconfigPath)
+		if err != nil {
+			return err
+		}
+
+		ev, err := version.EverestVersionFromDeployment(cmd.Context(), k)
+		if client.IgnoreNotFound(err) != nil {
+			cmdLogger.Error(err)
+			return err
+		}
+		sv := "[NOT INSTALLED]"
+		if ev != nil {
+			sv = fmt.Sprintf("v%s", ev.String())
+		}
+		v.ServerVersion = &sv
+	}
+
+	if rootCmdFlags.JSON {
+		_, _ = fmt.Fprintln(os.Stdout, v.JSONString())
+		return nil
+	}
+	_, _ = fmt.Fprintln(os.Stdout, v)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250117110506-e038d85918c5
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250121193034-147d57a451a2
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250115071212-bc3ad1c4c054
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
-	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.31.0
@@ -59,6 +58,11 @@ require (
 	k8s.io/kubectl v0.32.0
 	sigs.k8s.io/controller-runtime v0.19.4
 	sigs.k8s.io/yaml v1.4.0
+)
+
+require (
+	k8s.io/apiserver v0.32.0 // indirect
+	k8s.io/component-base v0.32.0 // indirect
 )
 
 require (
@@ -104,7 +108,6 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/flosch/pongo2/v6 v6.0.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.5.0 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
@@ -137,7 +140,6 @@ require (
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.3.1 // indirect
@@ -158,7 +160,6 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -180,7 +181,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/operator-framework/operator-registry v1.35.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 // indirect
 	github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd // indirect
 	github.com/percona/percona-server-mongodb-operator v1.18.0 // indirect
@@ -197,18 +197,13 @@ require (
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rubenv/sql-migrate v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sagikazarmark/locafero v0.4.0 // indirect
-	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/sourcegraph/conc v0.3.0 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
@@ -234,9 +229,6 @@ require (
 	google.golang.org/grpc v1.67.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
-	k8s.io/apiserver v0.32.0 // indirect
-	k8s.io/component-base v0.32.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1939,8 +1939,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
-github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
@@ -2058,8 +2056,6 @@ github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WV
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
-github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -2222,8 +2218,6 @@ github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
-github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932 h1:6rhZkr0rcA6jNf+/X4yNC1F0HiJUZRygbSgOx8krUDQ=
 github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932/go.mod h1:76ol+aF1CAkDey7kNkqmgtcjdTzJdEMFegfUiGS3q7M=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h1:OggdqSzqe9pO3A4GaRlrLwZXS3zEQ84O4+7Jm9cg74s=
@@ -2344,10 +2338,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
-github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
-github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
-github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
@@ -2366,8 +2356,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
-github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
-github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -2375,8 +2363,6 @@ github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY52
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
 github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
@@ -2392,8 +2378,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=
-github.com/spf13/viper v1.18.2/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMVB+yk=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
@@ -2420,8 +2404,6 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
-github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/substrait-io/substrait-go v0.4.2/go.mod h1:qhpnLmrcvAnlZsUyPXZRqldiHapPTXC3t7xFgDi3aQg=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -3585,8 +3567,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
-gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/go.sum
+++ b/go.sum
@@ -2222,8 +2222,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932/go.mod h1:76ol+aF1CAkDey7kNkqmgtcjdTzJdEMFegfUiGS3q7M=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h1:OggdqSzqe9pO3A4GaRlrLwZXS3zEQ84O4+7Jm9cg74s=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250117110506-e038d85918c5 h1:+cv7z5tYacTjX7qaya5HYfIp3FB16zmChFKmJTVFLOY=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250117110506-e038d85918c5/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250121193034-147d57a451a2 h1:TZmpFfIXmF6FWT9DcyUXsGbSI0dYU3XPlHV+wDcCILg=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250121193034-147d57a451a2/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.18.0 h1:inRWonCOTacD++D/tvyFXVUqKx7f2OQzz8w1NyT3cAI=

--- a/pkg/accounts/cli/accounts.go
+++ b/pkg/accounts/cli/accounts.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -28,31 +29,58 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/percona/everest/pkg/accounts"
+	cliutils "github.com/percona/everest/pkg/cli/utils"
+	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/output"
 )
 
 const (
 	minPasswordLength = 6
 )
 
-// CLI provides functionality for managing user accounts via the CLI.
-type CLI struct {
+// Accounts provides functionality for managing user accounts via the Accounts.
+type Accounts struct {
 	accountManager accounts.Interface
 	l              *zap.SugaredLogger
+	config         Config
+	kubeClient     *kubernetes.Kubernetes
 }
 
-// New creates a new CLI for running accounts commands.
-func New(l *zap.SugaredLogger) *CLI {
-	return &CLI{
-		l: l.With("component", "accounts"),
+// Config holds the configuration for the accounts subcommands.
+type Config struct {
+	// KubeconfigPath is a path to a kubeconfig
+	KubeconfigPath string
+	// If set, we will print the pretty output.
+	Pretty bool
+}
+
+// NewAccounts creates a new Accounts for running accounts commands.
+func NewAccounts(c Config, l *zap.SugaredLogger) (*Accounts, error) {
+	cli := &Accounts{
+		l:      l.With("component", "accounts"),
+		config: c,
 	}
+	if c.Pretty {
+		cli.l = zap.NewNop().Sugar()
+	}
+
+	k, err := cliutils.NewKubeclient(cli.l, c.KubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	cli.kubeClient = k
+	cli.accountManager = k.Accounts()
+
+	return cli, nil
 }
 
-// WithAccountManager sets the account manager for the CLI.
-func (c *CLI) WithAccountManager(m accounts.Interface) {
+// WithAccountManager sets the account manager for the Accounts.
+func (c *Accounts) WithAccountManager(m accounts.Interface) {
 	c.accountManager = m
 }
 
-func (c *CLI) runCredentialsWizard(username, password *string) error {
+func (c *Accounts) runCredentialsWizard(username, password *string) error {
 	if *username == "" {
 		pUsername := survey.Input{
 			Message: "Enter username",
@@ -72,22 +100,30 @@ func (c *CLI) runCredentialsWizard(username, password *string) error {
 	return nil
 }
 
+// SetPasswordOptions holds options for setting a new password for user accounts.
+type SetPasswordOptions struct {
+	// Username is the username for the account.
+	Username string
+	// NewPassword is a new password for the account.
+	NewPassword string
+}
+
 // SetPassword sets the password for an existing account.
-func (c *CLI) SetPassword(ctx context.Context, username, password string) error {
-	if username == "" {
+func (c *Accounts) SetPassword(ctx context.Context, opts SetPasswordOptions) error {
+	if opts.Username == "" {
 		pUsername := survey.Input{
 			Message: "Enter username",
 		}
-		if err := survey.AskOne(&pUsername, &username); err != nil {
+		if err := survey.AskOne(&pUsername, &opts.Username); err != nil {
 			return err
 		}
 	}
 
-	if username == "" {
+	if opts.Username == "" {
 		return errors.New("username is required")
 	}
 
-	if password == "" {
+	if opts.NewPassword == "" {
 		resp := struct {
 			Password     string
 			ConfPassword string
@@ -110,44 +146,61 @@ func (c *CLI) SetPassword(ctx context.Context, username, password string) error 
 		if resp.Password != resp.ConfPassword {
 			return errors.New("passwords do not match")
 		}
-		password = resp.Password
+		opts.NewPassword = resp.Password
 	}
 
-	if ok, msg := validateCredentials(username, password); !ok {
+	c.l.Infof("Setting a new password for user '%s'", opts.Username)
+	if ok, msg := validateCredentials(opts.Username, opts.NewPassword); !ok {
 		c.l.Error(msg)
 		return errors.New("invalid credentials")
 	}
 
-	if err := c.accountManager.SetPassword(ctx, username, password, true); err != nil {
+	if err := c.accountManager.SetPassword(ctx, opts.Username, opts.NewPassword, true); err != nil {
 		return err
 	}
-	c.l.Infof("Password updated for user '%s'", username)
+
+	c.l.Infof("Password for user '%s' has been set succesfully", opts.Username)
+	if c.config.Pretty {
+		_, _ = fmt.Fprintln(os.Stdout, output.Success("Password for user '%s' has been set successfully", opts.Username))
+	}
+
 	return nil
 }
 
+// CreateOptions holds options for creating a new user accounts.
+type CreateOptions struct {
+	// Username is the username for the account.
+	Username string
+	// Password is the password for the account.
+	Password string
+}
+
 // Create a new user account.
-func (c *CLI) Create(ctx context.Context, username, password string) error {
-	if err := c.runCredentialsWizard(&username, &password); err != nil {
+func (c *Accounts) Create(ctx context.Context, opts CreateOptions) error {
+	if err := c.runCredentialsWizard(&opts.Username, &opts.Password); err != nil {
 		return err
 	}
-	if username == "" {
-		return errors.New("username is required")
-	}
 
-	if ok, msg := validateCredentials(username, password); !ok {
+	if ok, msg := validateCredentials(opts.Username, opts.Password); !ok {
 		c.l.Error(msg)
 		return errors.New("invalid credentials")
 	}
 
-	if err := c.accountManager.Create(ctx, username, password); err != nil {
+	c.l.Infof("Creating user '%s'", opts.Username)
+	if err := c.accountManager.Create(ctx, opts.Username, opts.Password); err != nil {
 		return err
 	}
-	c.l.Infof("User '%s' has been created", username)
+
+	c.l.Infof("User '%s' has been created succesfully", opts.Username)
+	if c.config.Pretty {
+		_, _ = fmt.Fprintln(os.Stdout, output.Success("User '%s' has been created successfully", opts.Username))
+	}
+
 	return nil
 }
 
 // Delete an existing user account.
-func (c *CLI) Delete(ctx context.Context, username string) error {
+func (c *Accounts) Delete(ctx context.Context, username string) error {
 	if username == "" {
 		if err := survey.AskOne(&survey.Input{
 			Message: "Enter username",
@@ -159,28 +212,39 @@ func (c *CLI) Delete(ctx context.Context, username string) error {
 	if username == "" {
 		return errors.New("username is required")
 	}
-	return c.accountManager.Delete(ctx, username)
+
+	c.l.Infof("Deleting user '%s'", username)
+	if err := c.accountManager.Delete(ctx, username); err != nil {
+		return err
+	}
+
+	c.l.Infof("User '%s' has been deleted succesfully", username)
+	if c.config.Pretty {
+		_, _ = fmt.Fprintln(os.Stdout, output.Success("User '%s' has been deleted successfully", username))
+	}
+
+	return nil
 }
 
 // ListOptions holds options for listing user accounts.
 type ListOptions struct {
-	NoHeaders bool     `mapstructure:"no-headers"`
-	Columns   []string `mapstructure:"columns"`
+	NoHeaders bool
+	Columns   []string
 }
 
 const (
-	columnUser         = "user"
-	columnCapabilities = "capabilities"
-	columnEnabled      = "enabled"
+	// ColumnUser is the column name for the user.
+	ColumnUser = "user"
+	// ColumnCapabilities is the column name for the capabilities.
+	ColumnCapabilities = "capabilities"
+	// ColumnEnabled is the column name for the enabled status.
+	ColumnEnabled = "enabled"
 )
 
 // List all user accounts in the system.
-func (c *CLI) List(ctx context.Context, opts *ListOptions) error {
-	if opts == nil {
-		opts = &ListOptions{}
-	}
+func (c *Accounts) List(ctx context.Context, opts ListOptions) error {
 	// Prepare table headings.
-	headings := []interface{}{columnUser, columnCapabilities, columnEnabled}
+	headings := []interface{}{ColumnUser, ColumnCapabilities, ColumnEnabled}
 	if len(opts.Columns) > 0 {
 		headings = []interface{}{}
 		for _, col := range opts.Columns {
@@ -206,11 +270,11 @@ func (c *CLI) List(ctx context.Context, opts *ListOptions) error {
 		row := []any{}
 		for _, heading := range headings {
 			switch heading {
-			case "user":
+			case ColumnUser:
 				row = append(row, user)
-			case "capabilities":
+			case ColumnCapabilities:
 				row = append(row, account.Capabilities)
-			case "enabled":
+			case ColumnEnabled:
 				row = append(row, account.Enabled)
 			}
 		}
@@ -223,6 +287,23 @@ func (c *CLI) List(ctx context.Context, opts *ListOptions) error {
 	return nil
 }
 
+// GetInitAdminPassword returns the initial admin password.
+func (c *Accounts) GetInitAdminPassword(ctx context.Context) (string, error) {
+	secure, err := c.accountManager.IsSecure(ctx, common.EverestAdminUser)
+	if err != nil {
+		return "", err
+	}
+	if secure {
+		return "", errors.New("cannot retrieve admin password after it has been updated")
+	}
+
+	admin, err := c.accountManager.Get(ctx, common.EverestAdminUser)
+	if err != nil {
+		return "", err
+	}
+	return admin.PasswordHash, nil
+}
+
 func validateCredentials(username, password string) (bool, string) {
 	if !validateUsername(username) {
 		return false,
@@ -233,6 +314,21 @@ func validateCredentials(username, password string) (bool, string) {
 			"Password must contain only letters, numbers and specific special characters (@#$%^&+=!_), and must be at least 6 characters long"
 	}
 	return true, ""
+}
+
+// CreateRSAKeyPair creates a new RSA key pair for user authentication. New RSA key pair is stored in the Kubernetes secret.
+func (c *Accounts) CreateRSAKeyPair(ctx context.Context) error {
+	c.l.Info("Creating/Updating JWT keys and restarting Everest.")
+	if err := c.kubeClient.CreateRSAKeyPair(ctx); err != nil {
+		c.l.Error(err)
+		os.Exit(1)
+	}
+
+	c.l.Info("JWT keys have been created/updated successfully")
+	if c.config.Pretty {
+		_, _ = fmt.Fprintln(os.Stdout, output.Success("JWT keys have been created/updated successfully"))
+	}
+	return nil
 }
 
 func validateUsername(username string) bool {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -17,10 +17,17 @@
 package cli
 
 const (
+	// global flags
+
 	// FlagKubeconfig is the name of the kubeconfig flag.
 	FlagKubeconfig = "kubeconfig"
 	// FlagVerbose is the name of the verbose flag.
 	FlagVerbose = "verbose"
+	// FlagJSON is the name of the json flag.
+	FlagJSON = "json"
+
+	// `install` flags
+
 	// FlagOperatorPostgresql represents the pg operator flag.
 	FlagOperatorPostgresql = "operator.postgresql"
 	// FlagOperatorXtraDBCluster represents the pxc operator flag.
@@ -39,8 +46,40 @@ const (
 	FlagSkipEnvDetection = "skip-env-detection"
 	// FlagDisableTelemetry disables telemetry.
 	FlagDisableTelemetry = "disable-telemetry"
-	// FlagTakeNamespaceOwnership is the name of the take-ownership flag.
-	FlagTakeNamespaceOwnership = "take-ownership"
 	// FlagInstallSkipDBNamespace is the name of the skip-db-namespace flag.
 	FlagInstallSkipDBNamespace = "skip-db-namespace"
+
+	// `namespaces` flags
+
+	// FlagTakeNamespaceOwnership is the name of the take-ownership flag.
+	FlagTakeNamespaceOwnership = "take-ownership"
+	// FlagKeepNamespace is the name of the keep-namespace flag.
+	FlagKeepNamespace = "keep-namespace"
+	// FlagNamespaceForce is the name of the force flag.
+	FlagNamespaceForce = "force"
+
+	// `upgrade` flags
+
+	// FlagUpgradeDryRun is the name of the dry-run flag.
+	FlagUpgradeDryRun = "dry-run"
+	// FlagUpgradeInCluster is the name of the in-cluster flag.
+	FlagUpgradeInCluster = "in-cluster"
+
+	// `accounts` flags
+
+	// FlagAccountsUsername is the name of the username flag.
+	FlagAccountsUsername = "username"
+	// FlagAccountsCreatePassword is the name of the password flag.
+	FlagAccountsCreatePassword = "password"
+	// FlagAccountsNewPassword is the name of the new-password flag.
+	FlagAccountsNewPassword = "new-password"
+
+	// settings flags
+
+	// FlagOIDCIssueURL is the name of the issuer-url flag.
+	FlagOIDCIssueURL = "issuer-url"
+	// FlagOIDCIssueClientID is the name of the client-id flag.
+	FlagOIDCIssueClientID = "client-id"
+	// FlagRBACPolicyFile is the name of the policy-file flag.
+	FlagRBACPolicyFile = "policy-file"
 )

--- a/pkg/cli/helm/installer.go
+++ b/pkg/cli/helm/installer.go
@@ -26,7 +26,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -51,18 +50,6 @@ type CLIOptions struct {
 	ReuseValues          bool
 	ResetValues          bool
 	ResetThenReuseValues bool
-}
-
-// BindViperFlags parses the CLI flags from Viper and binds them to the CLI options.
-func (o *CLIOptions) BindViperFlags() {
-	o.Values.Values = viper.GetStringSlice(FlagHelmSet)
-	o.Values.ValueFiles = viper.GetStringSlice(FlagHelmValues)
-	o.ChartDir = viper.GetString(FlagChartDir)
-	o.RepoURL = viper.GetString(FlagRepository)
-	o.RepoURL = viper.GetString(FlagRepository)
-	o.ReuseValues = viper.GetBool(FlagHelmReuseValues)
-	o.ResetValues = viper.GetBool(FlagHelmResetValues)
-	o.ResetThenReuseValues = viper.GetBool(FlagHelmResetThenReuseValues)
 }
 
 // Everest Helm chart names.

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -28,12 +28,10 @@ import (
 	versionpb "github.com/Percona-Lab/percona-version-service/versionpb"
 	"github.com/fatih/color"
 	goversion "github.com/hashicorp/go-version"
-	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/percona/everest/pkg/cli"
 	"github.com/percona/everest/pkg/cli/helm"
 	helmutils "github.com/percona/everest/pkg/cli/helm/utils"
 	"github.com/percona/everest/pkg/cli/namespaces"
@@ -61,7 +59,6 @@ type Install struct {
 	l *zap.SugaredLogger
 
 	config         Config
-	cmd            *cobra.Command
 	kubeClient     *kubernetes.Kubernetes
 	versionService versionservice.Interface
 
@@ -74,29 +71,32 @@ type Install struct {
 // Config holds the configuration for the install command.
 type Config struct {
 	// KubeconfigPath is a path to a kubeconfig
-	KubeconfigPath string `mapstructure:"kubeconfig"`
+	KubeconfigPath string
 	// VersionMetadataURL stores hostname to retrieve version metadata information from.
-	VersionMetadataURL string `mapstructure:"version-metadata-url"`
+	VersionMetadataURL string
 	// Version defines the version to be installed. If empty, the latest version is installed.
-	Version string `mapstructure:"version"`
+	Version string
 	// DisableTelemetry disables telemetry.
-	DisableTelemetry bool `mapstructure:"disable-telemetry"`
+	DisableTelemetry bool
 	// SkipEnvDetection skips detecting the Kubernetes environment.
-	SkipEnvDetection bool `mapstructure:"skip-env-detection"`
+	SkipEnvDetection bool
 	// If set, we will print the pretty output.
 	Pretty bool
 	// SkipDBNamespace is set if the installation should skip provisioning database.
-	SkipDBNamespace bool `mapstructure:"skip-db-namespace"`
+	SkipDBNamespace bool
+	// Ask user to provide namespaces to be managed by Everest.
+	AskNamespaces bool
+	// Ask user to provide DB operators to be installed into namespaces managed by Everest.
+	AskOperators bool
 
 	helm.CLIOptions
-	namespaces.NamespaceAddConfig `mapstructure:",squash"`
+	namespaces.NamespaceAddConfig
 }
 
 // NewInstall returns a new Install struct.
-func NewInstall(c Config, l *zap.SugaredLogger, cmd *cobra.Command) (*Install, error) {
+func NewInstall(c Config, l *zap.SugaredLogger) (*Install, error) {
 	cli := &Install{
-		cmd: cmd,
-		l:   l.With("component", "install"),
+		l: l.With("component", "install"),
 	}
 	if c.Pretty {
 		cli.l = zap.NewNop().Sugar()
@@ -119,7 +119,7 @@ func NewInstall(c Config, l *zap.SugaredLogger, cmd *cobra.Command) (*Install, e
 
 // Run the Everest installation process.
 func (o *Install) Run(ctx context.Context) error {
-	// Do not continue if Everst is already installed.
+	// Do not continue if Everest is already installed.
 	installedVersion, err := version.EverestVersionFromDeployment(ctx, o.kubeClient)
 	if client.IgnoreNotFound(err) != nil {
 		return errors.Join(err, errors.New("cannot check if Everest is already installed"))
@@ -173,16 +173,7 @@ func (o *Install) Run(ctx context.Context) error {
 }
 
 func (o *Install) installDBNamespacesStep(ctx context.Context) (*steps.Step, error) {
-	askNamespaces := !(o.cmd.Flags().Lookup(cli.FlagNamespaces).Changed || o.config.SkipDBNamespace)
-	askOperators := !(o.cmd.Flags().Lookup(cli.FlagOperatorMongoDB).Changed ||
-		o.cmd.Flags().Lookup(cli.FlagOperatorPostgresql).Changed ||
-		o.cmd.Flags().Lookup(cli.FlagOperatorXtraDBCluster).Changed)
-
-	if askNamespaces {
-		o.config.Namespaces = DefaultDBNamespaceName
-	}
-
-	if err := o.config.Populate(ctx, askNamespaces, askOperators); err != nil {
+	if err := o.config.Populate(ctx, o.config.AskNamespaces, o.config.AskOperators); err != nil {
 		// not specifying a namespace in this context is allowed.
 		if errors.Is(err, namespaces.ErrNSEmpty) {
 			return nil, nil //nolint:nilnil

--- a/pkg/cli/uninstall/uninstall.go
+++ b/pkg/cli/uninstall/uninstall.go
@@ -37,13 +37,6 @@ import (
 const (
 	pollInterval = 5 * time.Second
 	pollTimeout  = 5 * time.Minute
-
-	// FlagCatalogNamespace is the name of the catalog namespace flag.
-	FlagCatalogNamespace = "catalog-namespace"
-	// FlagSkipEnvDetection is the name of the skip env detection flag.
-	FlagSkipEnvDetection = "skip-env-detection"
-	// FlagSkipOLM is the name of the skip OLM flag.
-	FlagSkipOLM = "skip-olm"
 )
 
 // Uninstall implements logic for the cluster command.
@@ -57,14 +50,13 @@ type Uninstall struct {
 // Config stores configuration for the Uninstall command.
 type Config struct {
 	// KubeconfigPath is a path to a kubeconfig
-	KubeconfigPath string `mapstructure:"kubeconfig"`
+	KubeconfigPath string
 	// AssumeYes is true when all questions can be skipped.
-	AssumeYes bool `mapstructure:"assume-yes"`
+	AssumeYes bool
 	// Force is true when we shall not prompt for removal.
 	Force bool
 	// SkipEnvDetection skips detecting the Kubernetes environment.
-	SkipEnvDetection bool `mapstructure:"skip-env-detection"`
-
+	SkipEnvDetection bool
 	// If set, we will print the pretty output.
 	Pretty bool
 }

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -68,7 +68,7 @@ func getProviderConfig(ctx context.Context, issuer string) (ProviderConfig, erro
 
 	var result ProviderConfig
 	if err := json.Unmarshal(body, &result); err != nil {
-		return ProviderConfig{}, fmt.Errorf("failed to unmarshal JSON response: %w", err)
+		return ProviderConfig{}, fmt.Errorf("failed to unmarshal json response: %w", err)
 	}
 	return result, nil
 }

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -62,11 +62,14 @@ const (
 	ActionRead   = "read"
 	ActionUpdate = "update"
 	ActionDelete = "delete"
+	ActionAll    = "*"
 )
 
 const (
 	rbacEnabledValueTrue = "true"
 )
+
+var SupportedActions = []string{ActionCreate, ActionRead, ActionUpdate, ActionDelete, ActionAll}
 
 // Setup a new informer that watches our RBAC ConfigMap.
 // This informer reloads the policy whenever the ConfigMap is updated.
@@ -298,4 +301,9 @@ func IsEnabled(cm *corev1.ConfigMap) bool {
 // ObjectName returns the a string that represents the name of an object in RBAC format.
 func ObjectName(args ...string) string {
 	return strings.Join(args, "/")
+}
+
+// ValidateAction validates the action is supported.
+func ValidateAction(action string) bool {
+	return slices.Contains(SupportedActions, action)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -74,7 +74,7 @@ func (v Info) String() string {
 	return strings.Join(out, "\n")
 }
 
-// JSONString returns the JSON representation of the version information.
+// JSONString returns the json representation of the version information.
 func (v Info) JSONString() string {
 	data, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
- Use spf13/cobra lib only for parsing CLI params
- Parse global flags (--verbose, --json, --kubeconfig) on root level
- Extend examples
- Use approach for commands initialisation suggested by cobra lib
