### PR TITLE
[UI] EVEREST-1803 Monitoring unavailable in db details widget when specific rule is set

### DIFF
--- a/ui/apps/everest/src/hooks/api/monitoring/useMonitoringInstancesList.ts
+++ b/ui/apps/everest/src/hooks/api/monitoring/useMonitoringInstancesList.ts
@@ -18,6 +18,7 @@ import {
   UseQueryResult,
   useMutation,
   useQueries,
+  useQuery,
 } from '@tanstack/react-query';
 import {
   getMonitoringInstancesFn,
@@ -76,6 +77,15 @@ export const useMonitoringInstancesList = (
   );
 
   return results;
+};
+
+export const useMonitoringInstancesForNamespace = (namespace: string) => {
+  return useQuery({
+    queryKey: [MONITORING_INSTANCES_QUERY_KEY, namespace],
+    retry: false,
+    queryFn: () => getMonitoringInstancesFn(namespace),
+    refetchInterval: 5 * 1000,
+  });
 };
 
 export const useCreateMonitoringInstance = (

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/db-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/db-details.tsx
@@ -21,8 +21,9 @@ import { BasicInformationSection } from './basic-information/basic';
 import { ConnectionDetails } from './connection-details';
 import { MonitoringDetails } from './monitoring/monitoring';
 import { AdvancedConfiguration } from './advanced-configuration';
-import { DbClusterContext } from 'pages/db-cluster-details/dbCluster.context';
-import { useContext } from 'react';
+import { useMemo } from 'react';
+import { useMonitoringInstancesForNamespace } from 'hooks';
+import { useRBACPermissions } from 'hooks/rbac';
 
 export const DbDetails = ({
   loading,
@@ -40,7 +41,22 @@ export const DbDetails = ({
   externalAccess,
   parameters,
 }: DatabaseDetailsOverviewCardProps) => {
-  const { canReadMonitoring } = useContext(DbClusterContext);
+  const { data: monitoringInstances } =
+    useMonitoringInstancesForNamespace(namespace);
+
+  const monitoringInstancesToCheck = useMemo(
+    () =>
+      (monitoringInstances || []).map(
+        (monitoringInstance) =>
+          `${monitoringInstance.namespace}/${monitoringInstance.name}`
+      ),
+    [monitoringInstances]
+  );
+
+  const { canRead: canReadMonitoring } = useRBACPermissions(
+    'monitoring-instances',
+    monitoringInstancesToCheck.length > 0 ? monitoringInstancesToCheck : '*'
+  );
 
   return (
     <OverviewCard

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/monitoring/monitoring.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/db-details/monitoring/monitoring.tsx
@@ -28,13 +28,12 @@ export const MonitoringDetails = ({
   monitoring,
 }: MonitoringConfigurationOverviewCardProps) => {
   const [openEditModal, setOpenEditModal] = useState(false);
-  const { dbCluster, canUpdateDb, canUpdateMonitoring } =
-    useContext(DbClusterContext);
+  const { dbCluster, canUpdateDb } = useContext(DbClusterContext);
   const restoringOrDeleting = [
     DbClusterStatus.restoring,
     DbClusterStatus.deleting,
   ].includes(dbCluster?.status?.status!);
-  const editable = canUpdateDb && !restoringOrDeleting && canUpdateMonitoring;
+  const editable = canUpdateDb && !restoringOrDeleting;
 
   const { mutate: updateDbClusterMonitoring } = useUpdateDbClusterMonitoring();
 

--- a/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.tsx
@@ -13,8 +13,6 @@ export const DbClusterContext = createContext<DbClusterContextProps>({
   dbCluster: {} as DbCluster,
   isLoading: false,
   canReadBackups: false,
-  canReadMonitoring: false,
-  canUpdateMonitoring: false,
   canReadCredentials: false,
   canUpdateDb: false,
   clusterDeleted: false,
@@ -59,8 +57,6 @@ export const DbClusterContextProvider = ({
     'database-cluster-backups',
     `${namespace}/${dbClusterName}`
   );
-  const { canRead: canReadMonitoring, canUpdate: canUpdateMonitoring } =
-    useRBACPermissions('monitoring-instances', `${namespace}/*`);
   const { canRead: canReadCredentials } = useRBACPermissions(
     'database-cluster-credentials',
     `${namespace}/${dbClusterName}`
@@ -97,8 +93,6 @@ export const DbClusterContextProvider = ({
         dbCluster,
         isLoading,
         canReadBackups,
-        canReadMonitoring,
-        canUpdateMonitoring,
         canUpdateDb,
         canReadCredentials,
         clusterDeleted,

--- a/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.types.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.types.ts
@@ -5,8 +5,6 @@ export interface DbClusterContextProps {
   dbCluster?: DbCluster;
   isLoading: boolean;
   canReadBackups: boolean;
-  canReadMonitoring: boolean;
-  canUpdateMonitoring: boolean;
   canUpdateDb: boolean;
   canReadCredentials: boolean;
   queryResult: QueryObserverResult<DbCluster, unknown>;


### PR DESCRIPTION
- [EVEREST-1803](https://perconadev.atlassian.net/browse/EVEREST-1803)
- removed `canUpdateMonitoring` from `editable` condition, as overview monitoring card is related to the db permissions, not the monitoring instance  
- we need to check if db has access to **any** of the monitoring instances, instead of `*`, so I moved the logic to the top component, to not load db context with unnecessary computations 

[EVEREST-1803]: https://perconadev.atlassian.net/browse/EVEREST-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ