### PR TITLE
EVEREST-1771 remove unused cookie

### DIFF
--- a/api-tests/tests/auth.spec.ts
+++ b/api-tests/tests/auth.spec.ts
@@ -25,20 +25,6 @@ test('auth header fails with invalid token', async ({ request }) => {
   expect(version.status()).toEqual(401);
 });
 
-test('auth header is preferred over cookie', async ({ browser }) => {
-  const ctx = await browser.newContext();
-
-  await ctx.addCookies([{
-    name: 'everest_token', value: '123', url: 'http://127.0.0.1:8080',
-  }]);
-
-  const request = ctx.request;
-
-  const version = await request.get('/v1/version');
-
-  await checkError(version);
-});
-
 test.describe('no authorization header', () => {
   test.use({
     extraHTTPHeaders: {
@@ -51,35 +37,5 @@ test.describe('no authorization header', () => {
     const version = await request.get('/v1/version');
 
     expect(version.status()).toEqual(401);
-  });
-
-  test('auth cookie fails with invalid token', async ({ browser }) => {
-    const ctx = await browser.newContext();
-
-    await ctx.addCookies([{
-      name: 'everest_token', value: '123', url: 'http://127.0.0.1:8080',
-    }]);
-
-    const request = ctx.request;
-
-    const version = await request.get('/v1/version');
-
-    expect(version.status()).toEqual(401);
-  });
-
-  test('auth cookie works with a valid token', async ({ page }) => {
-    const ctx = page.context();
-
-    await ctx.addCookies([{
-      name: 'everest_token',
-      value: process.env.API_TOKEN,
-      url: 'http://127.0.0.1:8080',
-    }]);
-
-    const request = ctx.request;
-
-    const version = await request.get('/v1/version');
-
-    await checkError(version);
   });
 });

--- a/internal/server/everest.go
+++ b/internal/server/everest.go
@@ -248,7 +248,6 @@ func (e *EverestServer) jwtMiddleWare(ctx context.Context) (echo.MiddlewareFunc,
 	}
 
 	tokenLookup := "header:Authorization:Bearer "
-	tokenLookup = tokenLookup + ",cookie:" + common.EverestTokenCookie
 	return echojwt.WithConfig(echojwt.Config{
 		Skipper:     skipper,
 		TokenLookup: tokenLookup,

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/percona/everest/api"
 	"github.com/percona/everest/pkg/accounts"
-	"github.com/percona/everest/pkg/common"
 )
 
 const (
@@ -62,10 +61,6 @@ func (e *EverestServer) CreateSession(ctx echo.Context) error {
 		return err
 	}
 
-	ctx.SetCookie(&http.Cookie{
-		Name:  common.EverestTokenCookie,
-		Value: jwtToken,
-	})
 	e.attemptsStore.CleanupVisitor(ctx.RealIP())
 
 	return ctx.JSON(http.StatusOK, map[string]string{"token": jwtToken})

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -69,8 +69,6 @@ const (
 
 	// EverestSettingsConfigMapName is the name of the Everest settings ConfigMap.
 	EverestSettingsConfigMapName = "everest-settings"
-	// EverestTokenCookie is the name of the cookie that holds the token.
-	EverestTokenCookie = "everest_token"
 	// EverestRBACConfigMapName is the name of the Everest RBAC ConfigMap.
 	EverestRBACConfigMapName = "everest-rbac"
 	// KubernetesManagedByLabel is the label used to identify resources managed by Everest.


### PR DESCRIPTION
EVEREST-1771

The `everest_token` cookie is a leftover from the old Everest. It is not used anymore and can be safely removed. 
