### PR TITLE
EVEREST-107 Trigger FB automatically

### DIFF
--- a/.github/workflows/feature-build-pr.yaml
+++ b/.github/workflows/feature-build-pr.yaml
@@ -1,0 +1,19 @@
+---
+name: Feature build (PR)
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+jobs:
+  feature-build:
+    name: Feature build
+    if: contains(github.event.pull_request.labels.*.name, 'feature-build')
+    uses: ./.github/workflows/feature-build.yaml
+    with:
+      vs_branch: ${{ github.event.pull_request.head.ref }}
+      helm_branch: ${{ github.event.pull_request.head.ref }}
+      everest_branch: ${{ github.event.pull_request.head.ref }}
+      everest_operator_branch: ${{ github.event.pull_request.head.ref }}
+      everest_catalog_branch: ${{ github.event.pull_request.head.ref }}
+      artifacts_retention_days: 30
+    secrets: inherit

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -101,6 +101,7 @@ jobs:
     steps:
       - name: Input validation
         run: |
+          echo "ARTIFACTS_RETENTION_DAYS=$ARTIFACTS_RETENTION_DAYS"
           if [[ ! "$ARTIFACTS_RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
             echo "Wrong artifacts_retention_days format. Use an integer number. 0 means default GitHub repo settings."
             exit 1

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -109,22 +109,22 @@ jobs:
           
       - name: Set environment variables
         run: |
-          echo "ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" >> $GITHUB_ENV
-          echo "OS=$(uname | awk '{print tolower($0)}')" >> $GITHUB_ENV
-          echo "VS_URL=http://localhost:$VS_PORT" >> $GITHUB_ENV
+          echo "ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" | tee -a $GITHUB_ENV
+          echo "OS=$(uname | awk '{print tolower($0)}')" | tee -a $GITHUB_ENV
+          echo "VS_URL=http://localhost:$VS_PORT" | tee -a $GITHUB_ENV
           
           TIMESTAMP=$(date +'%Y%m%d%H%M%S')
           V="1.10000.0-rc$TIMESTAMP"
-          echo "VERSION=$V" >> $GITHUB_ENV
-          echo "VERSION_TAG=v$V" >> $GITHUB_ENV
-          echo "VS_TAG=everest-test$TIMESTAMP" >> $GITHUB_ENV
+          echo "VERSION=$V" | tee -a $GITHUB_ENV
+          echo "VERSION_TAG=v$V" | tee -a $GITHUB_ENV
+          echo "VS_TAG=everest-test$TIMESTAMP" | tee -a $GITHUB_ENV
 
           # Fall back to default branch if the specified branch does not exist
-          git ls-remote --heads --exit-code --quiet https://github.com/Percona-Lab/percona-version-service.git $VS_BRANCH > /dev/null || echo "VS_BRANCH=production" >> $GITHUB_ENV
-          git ls-remote --heads --exit-code --quiet https://github.com/percona/percona-helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=main" >> $GITHUB_ENV
-          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest.git $EVEREST_BRANCH > /dev/null || echo "EVEREST_BRANCH=main" >> $GITHUB_ENV
-          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest-operator.git $EVEREST_OPERATOR_BRANCH > /dev/null || echo "EVEREST_OPERATOR_BRANCH=main" >> $GITHUB_ENV
-          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest-catalog.git $EVEREST_CATALOG_BRANCH > /dev/null || echo "EVEREST_CATALOG_BRANCH=main" >> $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/Percona-Lab/percona-version-service.git $VS_BRANCH > /dev/null || echo "VS_BRANCH=production" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/percona-helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=main" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest.git $EVEREST_BRANCH > /dev/null || echo "EVEREST_BRANCH=main" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest-operator.git $EVEREST_OPERATOR_BRANCH > /dev/null || echo "EVEREST_OPERATOR_BRANCH=main" | tee -a $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest-catalog.git $EVEREST_CATALOG_BRANCH > /dev/null || echo "EVEREST_CATALOG_BRANCH=main" | tee -a $GITHUB_ENV
 
       - name: Create temporary directory for storing artifacts
         run: |

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -27,6 +27,39 @@ on:
         required: false
         description: "How many days the artifacts will be stored in GitHub"
         default: 30
+  workflow_call:
+    inputs:
+      everest_branch:
+        required: false
+        type: string
+        default: main
+        description: "Everest branch with the feature to checkout"
+      everest_operator_branch:
+        required: false
+        type: string
+        default: main
+        description: "Everest operator branch with the feature to checkout"
+      everest_catalog_branch:
+        required: false
+        type: string
+        default: main
+        description: "Everest catalog branch with the feature to checkout"
+      vs_branch:
+        required: false
+        type: string
+        default: production
+        description: "Version Service branch with the feature to checkout"
+      helm_branch:
+        required: false
+        type: string
+        default: main
+        description: "Helm charts branch with the feature to checkout"
+      artifacts_retention_days:
+        required: false
+        type: number
+        description: "How many days the artifacts will be stored in GitHub"
+        default: 30
+
 
 permissions:
   contents: read
@@ -50,12 +83,12 @@ jobs:
 
     env:
       TOOLS_PATH: "/opt/tools/bin"
-      ARTIFACTS_RETENTION_DAYS: ${{ github.event.inputs.artifacts_retention_days }}
-      VS_BRANCH: ${{ github.event.inputs.vs_branch }}
-      HELM_BRANCH: ${{ github.event.inputs.helm_branch }}
-      EVEREST_BRANCH: ${{ github.event.inputs.everest_branch }}
-      EVEREST_OPERATOR_BRANCH: ${{ github.event.inputs.everest_operator_branch }}
-      EVEREST_CATALOG_BRANCH: ${{ github.event.inputs.everest_catalog_branch }}
+      ARTIFACTS_RETENTION_DAYS: ${{ inputs.artifacts_retention_days }}
+      VS_BRANCH: ${{ inputs.vs_branch }}
+      HELM_BRANCH: ${{ inputs.helm_branch }}
+      EVEREST_BRANCH: ${{ inputs.everest_branch }}
+      EVEREST_OPERATOR_BRANCH: ${{ inputs.everest_operator_branch }}
+      EVEREST_CATALOG_BRANCH: ${{ inputs.everest_catalog_branch }}
 
       VS_PORT: 8081
       ARCH: ""

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -11,6 +11,10 @@ on:
         required: false
         default: main
         description: "Everest operator branch with the feature to checkout"
+      everest_catalog_branch:
+        required: false
+        default: main
+        description: "Everest catalog branch with the feature to checkout"
       vs_branch:
         required: false
         default: production
@@ -19,18 +23,6 @@ on:
         required: false
         default: main
         description: "Helm charts branch with the feature to checkout"
-      upstream_operator:
-        type: choice
-        description: "The upstream operator to upgrade"
-        required: false
-        options:
-          - ""
-          - percona-xtradb-cluster-operator
-          - percona-server-mongodb-operator
-          - percona-postgresql-operator
-      upstream_operator_bundle_image:
-        required: false
-        description: "Full name of the upstream bundle image to test"
       artifacts_retention_days:
         required: false
         description: "How many days the artifacts will be stored in GitHub"
@@ -63,8 +55,7 @@ jobs:
       HELM_BRANCH: ${{ github.event.inputs.helm_branch }}
       EVEREST_BRANCH: ${{ github.event.inputs.everest_branch }}
       EVEREST_OPERATOR_BRANCH: ${{ github.event.inputs.everest_operator_branch }}
-      UPSTREAM_OPERATOR_IMAGE: ${{ github.event.inputs.upstream_operator_bundle_image }}
-      UPSTREAM_OPERATOR: ${{ github.event.inputs.upstream_operator }}
+      EVEREST_CATALOG_BRANCH: ${{ github.event.inputs.everest_catalog_branch }}
 
       VS_PORT: 8081
       ARCH: ""
@@ -82,11 +73,6 @@ jobs:
             exit 1
           fi
           
-          if [[ -z "$UPSTREAM_OPERATOR" && ! -z "$UPSTREAM_OPERATOR_IMAGE" ]] || [[ ! -z "$UPSTREAM_OPERATOR" && -z "$UPSTREAM_OPERATOR_IMAGE" ]]; then
-            echo "upstream_operator and upstream_operator_bundle_image should both be either empty or non-empty."
-            exit 1
-          fi
-
       - name: Set environment variables
         run: |
           echo "ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" >> $GITHUB_ENV
@@ -266,42 +252,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: percona/everest-catalog
+          ref: ${{ env.EVEREST_CATALOG_BRANCH }}
           path: everest-catalog
           token: ${{ secrets.ROBOT_TOKEN }}
-
-      - name: Catalog - update veneer file
-        run: |
-          cd everest-catalog/tools
-          go run . \
-            --veneer-file ../veneer/everest-operator.yaml \
-            --channel fast-v0  \
-            --new-version ${{ env.VERSION }} \
-
-          cd ..
-          curl -Lo /tmp/opm https://github.com/operator-framework/operator-registry/releases/download/v1.48.0/${OS}-${ARCH}-opm
-          chmod +x /tmp/opm
-          /tmp/opm alpha render-template basic --skip-tls -o yaml < veneer/everest-operator.yaml > catalog/everest-operator/catalog.yaml
-
-          # Check if catalog has the new version listed
-          if ! grep -q "$VERSION$" catalog/everest-operator/catalog.yaml; then
-            echo "catalog/everest-operator/catalog.yaml does not include the version $VERSION"
-            exit 1
-          fi
-
-          # If the feature build contains upstream upgrades
-          if [ -n "$UPSTREAM_OPERATOR" ]; then
-            # Add a new record to the upstream veneer
-            yq e ".Stable.Bundles += {\"Image\": \"$UPSTREAM_OPERATOR_IMAGE\"}" veneer/${UPSTREAM_OPERATOR}.yaml > temp.yaml && mv temp.yaml veneer/${UPSTREAM_OPERATOR}.yaml
-
-            # Generate upstream catalog
-            /tmp/opm alpha render-template semver --skip-tls -o yaml < veneer/${UPSTREAM_OPERATOR}.yaml > catalog/${UPSTREAM_OPERATOR}/catalog.yaml
-
-            # Check if upstream catalog has the new image listed
-            if ! grep -q "$UPSTREAM_OPERATOR_IMAGE$" catalog/${UPSTREAM_OPERATOR}/catalog.yaml; then
-              echo "catalog/${UPSTREAM_OPERATOR}/catalog.yaml does not include the version $UPSTREAM_OPERATOR_IMAGE"
-              exit 1
-            fi
-          fi
 
       - name: Catalog - setup Docker meta for everest-catalog
         id: catalog_meta

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -101,7 +101,6 @@ jobs:
     steps:
       - name: Input validation
         run: |
-          echo "ARTIFACTS_RETENTION_DAYS=$ARTIFACTS_RETENTION_DAYS"
           if [[ ! "$ARTIFACTS_RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
             echo "Wrong artifacts_retention_days format. Use an integer number. 0 means default GitHub repo settings."
             exit 1

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -118,6 +118,13 @@ jobs:
           echo "VERSION_TAG=v$V" >> $GITHUB_ENV
           echo "VS_TAG=everest-test$TIMESTAMP" >> $GITHUB_ENV
 
+          # Fall back to default branch if the specified branch does not exist
+          git ls-remote --heads --exit-code --quiet https://github.com/Percona-Lab/percona-version-service.git $VS_BRANCH > /dev/null || echo "VS_BRANCH=production" >> $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/percona-helm-charts.git $HELM_BRANCH > /dev/null || echo "HELM_BRANCH=main" >> $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest.git $EVEREST_BRANCH > /dev/null || echo "EVEREST_BRANCH=main" >> $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest-operator.git $EVEREST_OPERATOR_BRANCH > /dev/null || echo "EVEREST_OPERATOR_BRANCH=main" >> $GITHUB_ENV
+          git ls-remote --heads --exit-code --quiet https://github.com/percona/everest-catalog.git $EVEREST_CATALOG_BRANCH > /dev/null || echo "EVEREST_CATALOG_BRANCH=main" >> $GITHUB_ENV
+
       - name: Create temporary directory for storing artifacts
         run: |
           mkdir -p /tmp/${VERSION}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250117110506-e038d85918c5
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250121193034-147d57a451a2
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -2228,8 +2228,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250113063626-b38e7d1b3932/go.mod h1:76ol+aF1CAkDey7kNkqmgtcjdTzJdEMFegfUiGS3q7M=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h1:OggdqSzqe9pO3A4GaRlrLwZXS3zEQ84O4+7Jm9cg74s=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250117110506-e038d85918c5 h1:+cv7z5tYacTjX7qaya5HYfIp3FB16zmChFKmJTVFLOY=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250117110506-e038d85918c5/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250121193034-147d57a451a2 h1:TZmpFfIXmF6FWT9DcyUXsGbSI0dYU3XPlHV+wDcCILg=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250121193034-147d57a451a2/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.18.0 h1:inRWonCOTacD++D/tvyFXVUqKx7f2OQzz8w1NyT3cAI=


### PR DESCRIPTION
This PR adds the ability to automatically create feature builds for every PR labeled with `feature-build`. A new feature is built on every change to the PR.

To achieve this, the existing feature build workflow was changed to:
* Receive a catalog branch instead of an OLM bundle of an individual operator to upgrade
* Fallback to the default branches (main or production in the case of the VS repo) if the specified branch couldn't be found in the corresponding repo.

This new workflow assumes that the branches in the other repos have the same name of the branch of the PR.
E.g. if the branch of the PR is called `EVEREST-107-trigger-fb-automatically`, the branches for the everest-operator, everest-catalog, percona-helm-charts and percona-version-service must also be called `EVEREST-107-trigger-fb-automatically`. If these repos don't have such a branch, main (or production in the case of VS) will be used instead.
If custom branches need to be used, the feature build must be created manually using the existing action.