### PR TITLE
EVEREST-1714 DB Creating status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515
+	github.com/percona/everest-operator v0.6.0-dev1.0.20250210102602-127a3cde5e36
 	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250210102602-127a3cde5e36
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250206203544-2d61a898d367
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250130165745-fd11e0611fa8
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20250131090446-40b6d1d65b10
+	github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515
 	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250130165745-fd11e0611fa8
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -2219,8 +2219,8 @@ github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250131090446-40b6d1d65b10 h1:LI/o3pAYQdC+5h50MPbR7q4L7kMcuPN0TlsoiYxi4lc=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250131090446-40b6d1d65b10/go.mod h1:jpmlzDw0avyNWwmlBABbaHNZO4/G3q9AonI1GoXfQfE=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515 h1:mrmw3e9FBrY+WfNVVargYglaHGTi0wa7bFMdsWgeMhE=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515/go.mod h1:jpmlzDw0avyNWwmlBABbaHNZO4/G3q9AonI1GoXfQfE=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee h1:LtitxWyhBqCNjIZqdvsSEPBd2HPg11lDBlIExTQAbGQ=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee/go.mod h1:zikIUTNTflfcth3ZJRqhvW8+7Jj38aVlg+wSV1jwnxo=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250130165745-fd11e0611fa8 h1:4j5gNewAo45zr42kf9mp36s2ff5+OFZJEM26bvpyw1c=

--- a/go.sum
+++ b/go.sum
@@ -2223,8 +2223,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250210102602-127a3cde5e36 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250210102602-127a3cde5e36/go.mod h1:jpmlzDw0avyNWwmlBABbaHNZO4/G3q9AonI1GoXfQfE=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee h1:LtitxWyhBqCNjIZqdvsSEPBd2HPg11lDBlIExTQAbGQ=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee/go.mod h1:zikIUTNTflfcth3ZJRqhvW8+7Jj38aVlg+wSV1jwnxo=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052 h1:iTiSwfEzVWbFhTF9vu5/keuPZhqGZKUiBSGB52oAWos=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250206203544-2d61a898d367 h1:OawISaw1ZWLaLxddWTO9KGBuXofGY4KovB2hjPhW1+8=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250206203544-2d61a898d367/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.19.0 h1:X67Vx2jDYhSzyVfQZBKiVIjV3MICpyMLmon/m7y8tUo=

--- a/go.sum
+++ b/go.sum
@@ -2223,8 +2223,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515/go.mod h1:jpmlzDw0avyNWwmlBABbaHNZO4/G3q9AonI1GoXfQfE=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee h1:LtitxWyhBqCNjIZqdvsSEPBd2HPg11lDBlIExTQAbGQ=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee/go.mod h1:zikIUTNTflfcth3ZJRqhvW8+7Jj38aVlg+wSV1jwnxo=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250130165745-fd11e0611fa8 h1:4j5gNewAo45zr42kf9mp36s2ff5+OFZJEM26bvpyw1c=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250130165745-fd11e0611fa8/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052 h1:iTiSwfEzVWbFhTF9vu5/keuPZhqGZKUiBSGB52oAWos=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.19.0 h1:X67Vx2jDYhSzyVfQZBKiVIjV3MICpyMLmon/m7y8tUo=

--- a/go.sum
+++ b/go.sum
@@ -2219,8 +2219,8 @@ github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515 h1:mrmw3e9FBrY+WfNVVargYglaHGTi0wa7bFMdsWgeMhE=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250205133424-71ef43450515/go.mod h1:jpmlzDw0avyNWwmlBABbaHNZO4/G3q9AonI1GoXfQfE=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250210102602-127a3cde5e36 h1:1a3jkDP1pJVdJD1X9H9QLlzCr1ShtVzsCAT2/FO9Bfk=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250210102602-127a3cde5e36/go.mod h1:jpmlzDw0avyNWwmlBABbaHNZO4/G3q9AonI1GoXfQfE=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee h1:LtitxWyhBqCNjIZqdvsSEPBd2HPg11lDBlIExTQAbGQ=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee/go.mod h1:zikIUTNTflfcth3ZJRqhvW8+7Jj38aVlg+wSV1jwnxo=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250205100220-bfc757bae052 h1:iTiSwfEzVWbFhTF9vu5/keuPZhqGZKUiBSGB52oAWos=


### PR DESCRIPTION
[![EVEREST-1714](https://badgen.net/badge/JIRA/EVEREST-1714/green)](https://jira.percona.com/browse/EVEREST-1714) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

EVEREST-1714

**Problem:**
The DB can be in an ‘unknown’ state for a couple of seconds and we didn't want to show that to the user.
The related `everest-operator` PR adds the 'creating' state to the DB CR. From the BE side there is nothing left to do except of updating the `everest-operator` dependency to use the latest operator API, even though the DB statuses are not used in the codebase so far. 


**Related PRs:**
- https://github.com/percona/everest-operator/pull/653

[EVEREST-1714]: https://perconadev.atlassian.net/browse/EVEREST-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ