### PR TITLE
Fix init-deploy test

### DIFF
--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -212,7 +212,7 @@ test.describe.configure({ retries: 0 });
         if (size != 1 && db != 'postgresql') {
           await waitForStatus(page, clusterName, 'Stopping', 60000);
         }
-        await waitForStatus(page, clusterName, 'Paused', 180000);
+        await waitForStatus(page, clusterName, 'Paused', 240000);
       });
 
       test(`Resume cluster [${db} size ${size}]`, async ({ page }) => {


### PR DESCRIPTION
`init-deploy` test sporadically fails because suspending cluster can take a long time, so this increases the timeout.