### PR TITLE
EVEREST-1829 - Fix upgrade message test

### DIFF
--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -77,12 +77,12 @@ test.describe(
     );
     test.describe.configure({ timeout: 720000 });
 
-    const clusterName = `${db}-${size}-dembkp`;
+    const clusterName = `${db}-${size}-shard`;
 
     let storageClasses = [];
     const namespace = EVEREST_CI_NAMESPACES.EVEREST_UI;
     const monitoringName = `${db}-${size}-pmm`;
-    const baseBackupName = `dembkp-${db}-${size}`;
+    const baseBackupName = `shard-${db}-${size}`;
 
     test.beforeAll(async ({ request }) => {
       token = await getTokenFromLocalStorage();

--- a/ui/apps/everest/.e2e/upgrade/post-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/upgrade/post-upgrade.e2e.ts
@@ -2,7 +2,13 @@ import { expect, test } from '@playwright/test';
 import fs from 'fs';
 import { EVEREST_CI_NAMESPACES, TIMEOUTS } from '@e2e/constants';
 import {
-  expectedEverestUpgradeLog,
+  expectedEverestUpgradeAPILine,
+  expectedEverestUpgradeCatalogLine,
+  expectedEverestUpgradeCRDLine,
+  expectedEverestUpgradeFirstLine,
+  expectedEverestUpgradeHelmLine,
+  expectedEverestUpgradeLastLine,
+  expectedEverestUpgradeOperatorLine,
   mongoDBCluster,
   postgresDBCluster,
   pxcDBCluster,
@@ -37,10 +43,29 @@ test.describe('Post upgrade tests', { tag: '@post-upgrade' }, async () => {
   });
 
   test('Verify upgrade.log file', async () => {
+    let expectedText: string;
     const filePath = `/tmp/everest-upgrade.log`;
     const data = fs.readFileSync(filePath, 'utf8');
 
-    const expectedText = expectedEverestUpgradeLog();
+    expectedText = expectedEverestUpgradeFirstLine();
+    expect(data.trim()).toContain(expectedText);
+
+    expectedText = expectedEverestUpgradeCRDLine();
+    expect(data.trim()).toContain(expectedText);
+
+    expectedText = expectedEverestUpgradeHelmLine();
+    expect(data.trim()).toContain(expectedText);
+
+    expectedText = expectedEverestUpgradeAPILine();
+    expect(data.trim()).toContain(expectedText);
+
+    expectedText = expectedEverestUpgradeOperatorLine();
+    expect(data.trim()).toContain(expectedText);
+
+    expectedText = expectedEverestUpgradeCatalogLine();
+    expect(data.trim()).toContain(expectedText);
+
+    expectedText = expectedEverestUpgradeLastLine();
     expect(data.trim()).toContain(expectedText);
   });
 

--- a/ui/apps/everest/.e2e/upgrade/testData.ts
+++ b/ui/apps/everest/.e2e/upgrade/testData.ts
@@ -37,7 +37,7 @@ export const postgresDBCluster = {
   externalAccess: false,
 };
 
-export const expectedEverestUpgradeLog = (
+export const expectedEverestUpgradeFirstLine = (
   tag = everestTagForUpgrade.replace(/v/g, '')
 ) => {
   const version =
@@ -46,22 +46,37 @@ export const expectedEverestUpgradeLog = (
       ? everestFeatureBuildForUpgrade
       : tag;
 
-  return `ℹ️  Upgrading Everest to version ${version}
+  return `ℹ️  Upgrading Everest to version ${version}`;
+};
 
-✓ Upgrading Custom Resource Definitions
-✓ Upgrading Helm chart
-✓ Ensuring Everest API deployment is ready
-✓ Ensuring Everest operator deployment is ready
-✓ Ensuring Everest CatalogSource is ready
+export const expectedEverestUpgradeCRDLine = () => {
+  return `✅  Upgrading Custom Resource Definitions`;
+};
 
- 🚀 Everest has been upgraded to version ${version}
+export const expectedEverestUpgradeHelmLine = () => {
+  return `✅  Upgrading Helm chart`;
+};
 
+export const expectedEverestUpgradeAPILine = () => {
+  return `✅  Ensuring Everest API deployment is ready`;
+};
 
-Run the following command to get the initial admin password:
+export const expectedEverestUpgradeOperatorLine = () => {
+  return `✅  Ensuring Everest operator deployment is ready`;
+};
 
-	everestctl accounts initial-admin-password
+export const expectedEverestUpgradeCatalogLine = () => {
+  return `✅  Ensuring Everest CatalogSource is ready`;
+};
 
-NOTE: The initial password is stored in plain text. For security, change it immediately using the following command:
+export const expectedEverestUpgradeLastLine = (
+  tag = everestTagForUpgrade.replace(/v/g, '')
+) => {
+  const version =
+    typeof everestFeatureBuildForUpgrade !== 'undefined' &&
+    everestFeatureBuildForUpgrade
+      ? everestFeatureBuildForUpgrade
+      : tag;
 
-	everestctl accounts set-password --username admin`;
+  return ` 🚀 Everest has been upgraded to version ${version}`;
 };


### PR DESCRIPTION
This fixes the upgrade test for the new upgrade messages and also doesn't check whole output because now we have spinner (or progressbar) which add multiple lines in github action output.