### PR TITLE
EVEREST-1886 - Fix cluster deletion in sharding test

### DIFF
--- a/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
@@ -16,7 +16,10 @@ import {
 import { waitForDelete } from '@e2e/utils/table';
 import { execSync } from 'child_process';
 
-export const patchPSMDBFinalizers = async (cluster: string, namespace: string) => {
+export const patchPSMDBFinalizers = async (
+  cluster: string,
+  namespace: string
+) => {
   try {
     const command = `kubectl patch --namespace ${namespace} psmdb ${cluster} --type='merge' -p '{"metadata":{"finalizers":["percona.com/delete-psmdb-pvc"]}}'`;
     const output = execSync(command).toString();
@@ -143,7 +146,7 @@ test.describe('Sharding (psmdb)', () => {
 
     await deleteDbCluster(page, dbName);
     // TODO: This function should be removed after fix for: https://perconadev.atlassian.net/browse/K8SPSMDB-1208
-    await patchPSMDBFinalizers('sharding-psmdb','everest-ui');
+    await patchPSMDBFinalizers('sharding-psmdb', 'everest-ui');
     await waitForDelete(page, dbName, 60000);
   });
 

--- a/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts
@@ -14,6 +14,18 @@ import {
   findDbAndClickRow,
 } from '@e2e/utils/db-clusters-list';
 import { waitForDelete } from '@e2e/utils/table';
+import { execSync } from 'child_process';
+
+export const patchPSMDBFinalizers = async (cluster: string, namespace: string) => {
+  try {
+    const command = `kubectl patch --namespace ${namespace} psmdb ${cluster} --type='merge' -p '{"metadata":{"finalizers":["percona.com/delete-psmdb-pvc"]}}'`;
+    const output = execSync(command).toString();
+    return true;
+  } catch (error) {
+    console.error(`Error executing command: ${error}`);
+    throw error;
+  }
+};
 
 test.describe('Sharding (psmdb)', () => {
   let engineVersions = {
@@ -102,7 +114,7 @@ test.describe('Sharding (psmdb)', () => {
   test('Sharding should be correctly displayed on the overview page', async ({
     page,
   }) => {
-    test.setTimeout(1800 * 1000);
+    test.setTimeout(120 * 1000);
     const dbName = 'sharding-psmdb';
     expect(storageClasses.length).toBeGreaterThan(0);
     await selectDbEngine(page, 'psmdb');
@@ -130,8 +142,9 @@ test.describe('Sharding (psmdb)', () => {
     ).toBeVisible();
 
     await deleteDbCluster(page, dbName);
-    // TODO: Waiting for cluster deletion should be re-checked afer fix for: https://perconadev.atlassian.net/browse/EVEREST-1849
-    await waitForDelete(page, dbName, 18000000);
+    // TODO: This function should be removed after fix for: https://perconadev.atlassian.net/browse/K8SPSMDB-1208
+    await patchPSMDBFinalizers('sharding-psmdb','everest-ui');
+    await waitForDelete(page, dbName, 60000);
   });
 
   test('Mongo with sharding should not pass multinode cluster creation if config servers = 1', async ({


### PR DESCRIPTION
[![EVEREST-1886](https://badgen.net/badge/JIRA/EVEREST-1886/green)](https://jira.percona.com/browse/EVEREST-1886) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Cluster deletion in the sharding test (pr/db-cluster/db-wizard/create-db-cluster/sharding.e2e.ts) takes about 24 minutes which makes the whole test run unnecessary long and sporadically failing.

The root cause is this: K8SPSMDB-1208: Cluster stuck in initialising due to failed scheduling cannot be deleted
Open

But it will be fixed in some future PSMDB operator release so this ticket is to provide a workaround until it is fixed.

What we will do is we’ll patch the finalizers on cluster deletion to remove the problematic finalizer - it’s not important for our test anyway.

[EVEREST-1886]: https://perconadev.atlassian.net/browse/EVEREST-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ