### PR TITLE
Increase minikube memory to 12G for UI E2E tests

### DIFF
--- a/.github/workflows/dev-fe-e2e.yaml
+++ b/.github/workflows/dev-fe-e2e.yaml
@@ -85,7 +85,7 @@ jobs:
         id: minikube
         with:
           cpus: 4
-          memory: 4000m
+          memory: 12g
           addons: registry
           insecure-registry: "localhost:5000"
 


### PR DESCRIPTION
The github action node has 16G available so it should be safe to use 12G for minikube purpose.