### PR TITLE
Fix afterAll hook in release tests

### DIFF
--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -133,7 +133,7 @@ test.describe.configure({ retries: 0 });
             .getByRole('button')
             .getByText(size + ' node')
             .click();
-          await expect(page.getByText('Nº nodes: ' + size)).toBeVisible();
+          await expect(page.getByText('Nodes (' + size + ')')).toBeVisible();
           await populateResources(page, 0.6, 1, 1, size);
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -42,13 +42,12 @@ import {
 import { clickOnDemandBackup } from '@e2e/pr/db-cluster-details/utils';
 import { prepareTestDB, dropTestDB, queryTestDB } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
+import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
 const {
   MONITORING_URL,
   MONITORING_USER,
   MONITORING_PASSWORD,
-  SELECT_DB,
-  SELECT_SIZE,
 } = process.env;
 let token: string;
 
@@ -65,11 +64,7 @@ test.describe.configure({ retries: 0 });
       tag: '@release',
     },
     () => {
-      test.skip(
-        () =>
-          (SELECT_DB !== db && !!SELECT_DB) ||
-          (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
-      );
+      test.skip(!shouldExecuteDBCombination(db, size));
       test.describe.configure({ timeout: 720000 });
 
       const clusterName = `${db}-${size}-dembkp`;
@@ -91,7 +86,7 @@ test.describe.configure({ retries: 0 });
 
       test.afterAll(async ({ request }) => {
         // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
-        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+        if (shouldExecuteDBCombination(db, size)) {
           // we try to delete all monitoring instances because cluster creation expects that none exist
           // (monitoring instance is added in the form where the warning that none exist is visible)
           const monitoringInstances = await listMonitoringInstances(

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -90,20 +90,23 @@ test.describe.configure({ retries: 0 });
       });
 
       test.afterAll(async ({ request }) => {
-        // we try to delete all monitoring instances because cluster creation expects that none exist
-        // (monitoring instance is added in the form where the warning that none exist is visible)
-        const monitoringInstances = await listMonitoringInstances(
-          request,
-          namespace,
-          token
-        );
-        for (const instance of monitoringInstances) {
-          await deleteMonitoringInstance(
+        // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
+        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+          // we try to delete all monitoring instances because cluster creation expects that none exist
+          // (monitoring instance is added in the form where the warning that none exist is visible)
+          const monitoringInstances = await listMonitoringInstances(
             request,
             namespace,
-            instance.name,
             token
           );
+          for (const instance of monitoringInstances) {
+            await deleteMonitoringInstance(
+              request,
+              namespace,
+              instance.name,
+              token
+            );
+          }
         }
       });
 

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -44,11 +44,7 @@ import { prepareTestDB, dropTestDB, queryTestDB } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
 import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
-const {
-  MONITORING_URL,
-  MONITORING_USER,
-  MONITORING_PASSWORD,
-} = process.env;
+const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD } = process.env;
 let token: string;
 
 test.describe.configure({ retries: 0 });

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -134,7 +134,8 @@ test.describe.configure({ retries: 0 });
             .getByRole('button')
             .getByText(size + ' node')
             .click();
-          await expect(page.getByText('Nº nodes: ' + size)).toBeVisible();
+
+          await expect(page.getByText('Nodes (' + size + ')')).toBeVisible();
           await populateResources(page, 0.6, 1, 1, size);
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -37,13 +37,12 @@ import {
   listMonitoringInstances,
 } from '@e2e/utils/monitoring-instance';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
+import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
 const {
   MONITORING_URL,
   MONITORING_USER,
   MONITORING_PASSWORD,
-  SELECT_DB,
-  SELECT_SIZE,
 } = process.env;
 let token: string;
 
@@ -63,11 +62,7 @@ test.describe.configure({ retries: 0 });
       tag: '@release',
     },
     () => {
-      test.skip(
-        () =>
-          (SELECT_DB !== db && !!SELECT_DB) ||
-          (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
-      );
+      test.skip(!shouldExecuteDBCombination(db, size));
       test.describe.configure({ timeout: 720000 });
 
       const clusterName = `${db}-${size}-deploy`;
@@ -88,7 +83,7 @@ test.describe.configure({ retries: 0 });
 
       test.afterAll(async ({ request }) => {
         // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
-        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+        if (shouldExecuteDBCombination(db, size)) {
           // we try to delete all monitoring instances because cluster creation expects that none exist
           // (monitoring instance is added in the form where the warning that none exist is visible)
           const monitoringInstances = await listMonitoringInstances(

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -39,11 +39,7 @@ import {
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
 import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
-const {
-  MONITORING_URL,
-  MONITORING_USER,
-  MONITORING_PASSWORD,
-} = process.env;
+const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD } = process.env;
 let token: string;
 
 test.describe.configure({ retries: 0 });

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -87,20 +87,24 @@ test.describe.configure({ retries: 0 });
       });
 
       test.afterAll(async ({ request }) => {
-        // we try to delete all monitoring instances because cluster creation expects that none exist
-        // (monitoring instance is added in the form where the warning that none exist is visible)
-        const monitoringInstances = await listMonitoringInstances(
-          request,
-          namespace,
-          token
-        );
-        for (const instance of monitoringInstances) {
-          await deleteMonitoringInstance(
+        // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
+        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+          // we try to delete all monitoring instances because cluster creation expects that none exist
+          // (monitoring instance is added in the form where the warning that none exist is visible)
+          const monitoringInstances = await listMonitoringInstances(
             request,
             namespace,
-            instance.name,
             token
           );
+
+          for (const instance of monitoringInstances) {
+            await deleteMonitoringInstance(
+              request,
+              namespace,
+              instance.name,
+              token
+            );
+          }
         }
       });
 

--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -182,7 +182,7 @@ test.describe.configure({ retries: 0 });
             .getByRole('button')
             .getByText(size + ' node')
             .click();
-          await expect(page.getByText('Nº nodes: ' + size)).toBeVisible();
+          await expect(page.getByText('Nodes (' + size + ')')).toBeVisible();
           await populateResources(page, 0.6, 1, 1, size);
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -52,11 +52,7 @@ import { addFirstScheduleInDBWizard } from '@e2e/pr/db-cluster/db-wizard/db-wiza
 import { getDbClusterAPI, updateDbClusterAPI } from '@e2e/utils/db-cluster';
 import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
-const {
-  MONITORING_URL,
-  MONITORING_USER,
-  MONITORING_PASSWORD,
-} = process.env;
+const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD } = process.env;
 
 type pitrTime = {
   day: string;

--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -139,20 +139,23 @@ test.describe.configure({ retries: 0 });
       });
 
       test.afterAll(async ({ request }) => {
-        // we try to delete all monitoring instances because cluster creation expects that none exist
-        // (monitoring instance is added in the form where the warning that none exist is visible)
-        const monitoringInstances = await listMonitoringInstances(
-          request,
-          namespace,
-          token
-        );
-        for (const instance of monitoringInstances) {
-          await deleteMonitoringInstance(
+        // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
+        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+          // we try to delete all monitoring instances because cluster creation expects that none exist
+          // (monitoring instance is added in the form where the warning that none exist is visible)
+          const monitoringInstances = await listMonitoringInstances(
             request,
             namespace,
-            instance.name,
             token
           );
+          for (const instance of monitoringInstances) {
+            await deleteMonitoringInstance(
+              request,
+              namespace,
+              instance.name,
+              token
+            );
+          }
         }
       });
 

--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -95,20 +95,23 @@ test.describe(
     });
 
     test.afterAll(async ({ request }) => {
-      // we try to delete all monitoring instances because cluster creation expects that none exist
-      // (monitoring instance is added in the form where the warning that none exist is visible)
-      const monitoringInstances = await listMonitoringInstances(
-        request,
-        namespace,
-        token
-      );
-      for (const instance of monitoringInstances) {
-        await deleteMonitoringInstance(
+      // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
+      if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+        // we try to delete all monitoring instances because cluster creation expects that none exist
+        // (monitoring instance is added in the form where the warning that none exist is visible)
+        const monitoringInstances = await listMonitoringInstances(
           request,
           namespace,
-          instance.name,
           token
         );
+        for (const instance of monitoringInstances) {
+          await deleteMonitoringInstance(
+            request,
+            namespace,
+            instance.name,
+            token
+          );
+        }
       }
     });
 

--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -49,13 +49,12 @@ import {
   queryTestDB,
 } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
+import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
 const {
   MONITORING_URL,
   MONITORING_USER,
   MONITORING_PASSWORD,
-  SELECT_DB,
-  SELECT_SIZE,
 } = process.env;
 let token: string;
 
@@ -70,11 +69,6 @@ test.describe(
     tag: '@release',
   },
   () => {
-    test.skip(
-      () =>
-        (SELECT_DB !== db && !!SELECT_DB) ||
-        (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
-    );
     test.describe.configure({ timeout: 720000 });
 
     const clusterName = `${db}-${size}-shard`;
@@ -96,7 +90,7 @@ test.describe(
 
     test.afterAll(async ({ request }) => {
       // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
-      if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+      if (shouldExecuteDBCombination(db, size)) {
         // we try to delete all monitoring instances because cluster creation expects that none exist
         // (monitoring instance is added in the form where the warning that none exist is visible)
         const monitoringInstances = await listMonitoringInstances(

--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -145,7 +145,7 @@ test.describe(
           .getByText(size + ' nodes')
           .click();
 
-        await expect(page.getByText('Nº nodes: ' + size)).toBeVisible();
+        await expect(page.getByText('Nodes (' + size + ')')).toBeVisible();
         await populateResources(page, 0.6, 1, 1, size, 2, 0.6, 1, 2, 3);
         await moveForward(page);
       });

--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -51,11 +51,7 @@ import {
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
 import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
-const {
-  MONITORING_URL,
-  MONITORING_USER,
-  MONITORING_PASSWORD,
-} = process.env;
+const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD } = process.env;
 let token: string;
 
 const db = 'psmdb';

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -48,11 +48,7 @@ import { prepareTestDB, dropTestDB, queryTestDB } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
 import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
-const {
-  MONITORING_URL,
-  MONITORING_USER,
-  MONITORING_PASSWORD,
-} = process.env;
+const { MONITORING_URL, MONITORING_USER, MONITORING_PASSWORD } = process.env;
 let token: string;
 
 test.describe.configure({ retries: 0 });

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -46,13 +46,12 @@ import {
 import { clickCreateSchedule } from '@e2e/pr/db-cluster-details/utils';
 import { prepareTestDB, dropTestDB, queryTestDB } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
+import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
 const {
   MONITORING_URL,
   MONITORING_USER,
   MONITORING_PASSWORD,
-  SELECT_DB,
-  SELECT_SIZE,
 } = process.env;
 let token: string;
 
@@ -76,11 +75,7 @@ function getNextScheduleMinute(incrementMinutes: number): string {
       tag: '@release',
     },
     () => {
-      test.skip(
-        () =>
-          (SELECT_DB !== db && !!SELECT_DB) ||
-          (SELECT_SIZE !== size.toString() && !!SELECT_SIZE)
-      );
+      test.skip(!shouldExecuteDBCombination(db, size));
       test.describe.configure({ timeout: 720000 });
 
       const clusterName = `${db}-${size}-schbkp`;
@@ -101,7 +96,7 @@ function getNextScheduleMinute(incrementMinutes: number): string {
 
       test.afterAll(async ({ request }) => {
         // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
-        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+        if (shouldExecuteDBCombination(db, size)) {
           // we try to delete all monitoring instances because cluster creation expects that none exist
           // (monitoring instance is added in the form where the warning that none exist is visible)
           const monitoringInstances = await listMonitoringInstances(

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -100,20 +100,23 @@ function getNextScheduleMinute(incrementMinutes: number): string {
       });
 
       test.afterAll(async ({ request }) => {
-        // we try to delete all monitoring instances because cluster creation expects that none exist
-        // (monitoring instance is added in the form where the warning that none exist is visible)
-        const monitoringInstances = await listMonitoringInstances(
-          request,
-          namespace,
-          token
-        );
-        for (const instance of monitoringInstances) {
-          await deleteMonitoringInstance(
+        // Playwright decided to execute only afterAll hook even if the group is skipped so we need a condition here
+        if ((SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)) {
+          // we try to delete all monitoring instances because cluster creation expects that none exist
+          // (monitoring instance is added in the form where the warning that none exist is visible)
+          const monitoringInstances = await listMonitoringInstances(
             request,
             namespace,
-            instance.name,
             token
           );
+          for (const instance of monitoringInstances) {
+            await deleteMonitoringInstance(
+              request,
+              namespace,
+              instance.name,
+              token
+            );
+          }
         }
       });
 

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -141,7 +141,7 @@ function getNextScheduleMinute(incrementMinutes: number): string {
             .getByText(size + ' node')
             .click();
 
-          await expect(page.getByText('Nº nodes: ' + size)).toBeVisible();
+          await expect(page.getByText('Nodes (' + size + ')')).toBeVisible();
           await populateResources(page, 0.6, 1, 1, size);
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/utils/generic.ts
+++ b/ui/apps/everest/.e2e/utils/generic.ts
@@ -17,6 +17,11 @@ import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import { everestFeatureBuildForUpgrade } from '@e2e/constants';
 
+const {
+  SELECT_DB,
+  SELECT_SIZE,
+} = process.env;
+
 export const checkError = async (response) => {
   if (!response.ok()) {
     console.log(`${response.url()}: `, await response.json());
@@ -41,4 +46,8 @@ export const getVersionServiceURL = async () => {
       throw error;
     }
   }
+};
+
+export const shouldExecuteDBCombination = (db: string, size: number) => {
+  return (SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true);
 };

--- a/ui/apps/everest/.e2e/utils/generic.ts
+++ b/ui/apps/everest/.e2e/utils/generic.ts
@@ -17,10 +17,7 @@ import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import { everestFeatureBuildForUpgrade } from '@e2e/constants';
 
-const {
-  SELECT_DB,
-  SELECT_SIZE,
-} = process.env;
+const { SELECT_DB, SELECT_SIZE } = process.env;
 
 export const checkError = async (response) => {
   if (!response.ok()) {
@@ -49,5 +46,8 @@ export const getVersionServiceURL = async () => {
 };
 
 export const shouldExecuteDBCombination = (db: string, size: number) => {
-  return (SELECT_DB ? SELECT_DB === db : true) && (SELECT_SIZE ? SELECT_SIZE === size.toString() : true);
+  return (
+    (SELECT_DB ? SELECT_DB === db : true) &&
+    (SELECT_SIZE ? SELECT_SIZE === size.toString() : true)
+  );
 };


### PR DESCRIPTION
At some point Playwright decided that they want to execute only afterAll hook (beforeAll hook is skipped) even if the whole test group is skipped so we need to add a condition in afterAll hook to not execute the content if the group is skipped.