### PR TITLE
EVEREST-1754 | do exponential backoff for HTTP 429

### DIFF
--- a/ui/apps/everest/src/App.tsx
+++ b/ui/apps/everest/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeContextProvider, everestThemeOptions } from '@percona/design';
 import { NotistackMuiSnackbar } from '@percona/ui-lib';
 import { SnackbarProvider } from 'notistack';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { RouterProvider } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AuthProvider } from 'contexts/auth';
@@ -19,6 +20,8 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      retry: (failureCount, error) =>
+        (error as AxiosError).status === 429 ? failureCount < 4 : false,
     },
   },
 });

--- a/ui/apps/everest/src/api/api.ts
+++ b/ui/apps/everest/src/api/api.ts
@@ -37,7 +37,8 @@ export const addApiErrorInterceptor = () => {
           error.response.status <= 500
         ) {
           let message = error.response.data?.message ?? DEFAULT_ERROR_MESSAGE;
-          let notificationsDisabled = error.config?.disableNotifications;
+          let notificationsDisabled =
+            error.config?.disableNotifications ?? error.status === 429;
 
           if (typeof notificationsDisabled === 'function') {
             notificationsDisabled = notificationsDisabled(error);

--- a/ui/apps/everest/src/hooks/api/backup-storages/useBackupStorages.ts
+++ b/ui/apps/everest/src/hooks/api/backup-storages/useBackupStorages.ts
@@ -44,7 +44,6 @@ export const useBackupStorages = () => {
   const queries = namespaces.map((namespace) => {
     return {
       queryKey: [BACKUP_STORAGES_QUERY_KEY, namespace],
-      retry: false,
       queryFn: () => getBackupStoragesFn(namespace),
       refetchInterval: 5 * 1000,
     };

--- a/ui/apps/everest/src/hooks/api/db-clusters/useDbClusters.ts
+++ b/ui/apps/everest/src/hooks/api/db-clusters/useDbClusters.ts
@@ -80,7 +80,6 @@ export const useDBClustersForNamespaces = (
   >(({ namespace, options }) => {
     return {
       queryKey: [DB_CLUSTERS_QUERY_KEY, namespace],
-      retry: false,
       queryFn: () => getDbClustersFn(namespace),
       refetchInterval: 5 * 1000,
       select: dbClustersQuerySelect,

--- a/ui/apps/everest/src/hooks/api/db-engines/useDbEngines.ts
+++ b/ui/apps/everest/src/hooks/api/db-engines/useDbEngines.ts
@@ -124,7 +124,7 @@ export const useDbEngines = (
     queryKey: ['dbEngines', namespace],
     queryFn: () => getDbEnginesFn(namespace),
     select: (data) => dbEnginesQuerySelect(data, retrieveUpgradingEngines),
-    retry: 2,
+    retry: 3,
     ...options,
     enabled: !!namespace && (options?.enabled ?? true),
   });

--- a/ui/apps/everest/src/hooks/api/monitoring/useMonitoringInstancesList.ts
+++ b/ui/apps/everest/src/hooks/api/monitoring/useMonitoringInstancesList.ts
@@ -61,7 +61,6 @@ export const useMonitoringInstancesList = (
   >(({ namespace, options }) => {
     return {
       queryKey: [MONITORING_INSTANCES_QUERY_KEY, namespace],
-      retry: false,
       queryFn: () => getMonitoringInstancesFn(namespace),
       refetchInterval: 5 * 1000,
       ...options,
@@ -82,7 +81,6 @@ export const useMonitoringInstancesList = (
 export const useMonitoringInstancesForNamespace = (namespace: string) => {
   return useQuery({
     queryKey: [MONITORING_INSTANCES_QUERY_KEY, namespace],
-    retry: false,
     queryFn: () => getMonitoringInstancesFn(namespace),
     refetchInterval: 5 * 1000,
   });

--- a/ui/apps/everest/src/hooks/api/namespaces/useNamespaces.ts
+++ b/ui/apps/everest/src/hooks/api/namespaces/useNamespaces.ts
@@ -48,7 +48,6 @@ export const useDBEnginesForNamespaces = (
     UseQueryOptions<DbEngine[], unknown, DbEngine[]>
   >((namespace) => ({
     queryKey: ['dbEngines-multi', namespace],
-    retry: false,
     // We don't use "select" here so that our cache saves data already formatted
     // Otherwise, every render from components cause "select" to be called, which means new values on every render
     queryFn: async () => {

--- a/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/dbCluster.context.tsx
@@ -37,7 +37,6 @@ export const DbClusterContextProvider = ({
     {
       enabled: !!namespace && !!dbClusterName && !clusterDeleted,
       refetchInterval: refetchInterval,
-      retry: false,
     }
   );
 


### PR DESCRIPTION
Do exponential backoff for failed requests with HTTP 429.
4 retries are set, meaning the timeline for the requests is:
- Original request at t = 0;
- Retry #1 at t = 1s;
- Retry #2 at t = 2s;
- Retry #3 at t = 4s;
- Retry #4 at t = 8s;


https://github.com/user-attachments/assets/99632063-280a-4ff5-8193-d00fad64ed8e

