### PR TITLE
EVEREST-1904 - Check if DB custom options passed correctly

### DIFF
--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -174,17 +174,31 @@ test.describe.configure({ retries: 0 });
 
         switch (db) {
           case 'pxc': {
-            result = await queryMySQL(clusterName, namespace, `SHOW variables LIKE "max_connections";`);
+            result = await queryMySQL(
+              clusterName,
+              namespace,
+              `SHOW variables LIKE "max_connections";`
+            );
             expect(result.trim()).toBe('max_connections	250');
             break;
           }
           case 'psmdb': {
-            result = await queryPSMDB(clusterName, namespace, 'admin', `db.serverCmdLineOpts().parsed.systemLog;`);
+            result = await queryPSMDB(
+              clusterName,
+              namespace,
+              'admin',
+              `db.serverCmdLineOpts().parsed.systemLog;`
+            );
             expect(result.trim()).toBe('{ quiet: true, verbosity: 1 }');
             break;
           }
           case 'postgresql': {
-            result = await queryPG(clusterName, namespace, 'postgres', `SHOW shared_buffers;`);
+            result = await queryPG(
+              clusterName,
+              namespace,
+              'postgres',
+              `SHOW shared_buffers;`
+            );
             expect(result.trim()).toBe('192MB');
             break;
           }

--- a/ui/apps/everest/.e2e/utils/db-wizard.ts
+++ b/ui/apps/everest/.e2e/utils/db-wizard.ts
@@ -238,7 +238,7 @@ export const populateAdvancedConfig = async (
           inputParameters = 'systemLog:\n verbosity: 1';
           break;
         case 'postgresql':
-          inputParameters = 'log_connections = yes\nshared_buffers = 128MB';
+          inputParameters = 'log_connections = yes\nshared_buffers = 192MB';
           break;
         case 'pxc':
         default:


### PR DESCRIPTION
[![EVEREST-1904](https://badgen.net/badge/JIRA/EVEREST-1904/green)](https://jira.percona.com/browse/EVEREST-1904) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We were passing custom DB options previously in our tests, but we were not checking if they were actually applied so this PR is to add assertion for that.

[EVEREST-1904]: https://perconadev.atlassian.net/browse/EVEREST-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ