### PR TITLE
UI tests - Fail global setup if storage or monitoring endpoints not created

### DIFF
--- a/ui/apps/everest/.e2e/setup/global.setup.ts
+++ b/ui/apps/everest/.e2e/setup/global.setup.ts
@@ -46,6 +46,10 @@ const doBackupCall = async (fn: () => Promise<APIResponse>, retries = 3) => {
       return Promise.resolve();
     }
 
+    if (response.status() !== 201 && response.status() !== 200) {
+      Promise.reject();
+    }
+
     if (statusText && statusText.message) {
       if (statusText.message.includes('Could not read')) {
         if (retries > 0) {

--- a/ui/apps/everest/.e2e/setup/global.setup.ts
+++ b/ui/apps/everest/.e2e/setup/global.setup.ts
@@ -47,7 +47,7 @@ const doBackupCall = async (fn: () => Promise<APIResponse>, retries = 3) => {
     }
 
     if (response.status() !== 201 && response.status() !== 200) {
-      Promise.reject();
+      return Promise.reject();
     }
 
     if (statusText && statusText.message) {


### PR DESCRIPTION
Currently if `minio` or `PMM` are not running the global setup just marks the setup as passed, but the tests will just fail and it doesn't make sense to run them.