### PR TITLE
EVEREST-1772 Disable upgrade-insecure-requests CSP directive

### DIFF
--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -117,12 +117,15 @@ func securityHeaders(oidcProvider *oidc.ProviderConfig) echo.MiddlewareFunc {
 				// https://github.com/emotion-js/emotion/issues/2996
 				"'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
 			},
-			cspbuilder.FormAction:              {CSPSelf},
-			cspbuilder.BaseURI:                 {CSPSelf},
-			cspbuilder.ObjectSrc:               {CSPNone},
-			cspbuilder.FrameAncestors:          {CSPNone},
-			cspbuilder.UpgradeInsecureRequests: {},
-			cspbuilder.ConnectSrc:              connectSrc,
+			cspbuilder.FormAction:     {CSPSelf},
+			cspbuilder.BaseURI:        {CSPSelf},
+			cspbuilder.ObjectSrc:      {CSPNone},
+			cspbuilder.FrameAncestors: {CSPNone},
+			// TODO (EVEREST-1180): Once we have native support for TLS, we
+			// should probably redirect all HTTP traffic to HTTPS and set the
+			// upgrade-insecure-requests directive.
+			// cspbuilder.UpgradeInsecureRequests: {},
+			cspbuilder.ConnectSrc: connectSrc,
 		},
 	}
 


### PR DESCRIPTION
[![EVEREST-1772](https://badgen.net/badge/JIRA/EVEREST-1772/green)](https://jira.percona.com/browse/EVEREST-1772) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Until we natively support HTTPS we should remove this directive.

[EVEREST-1772]: https://perconadev.atlassian.net/browse/EVEREST-1772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ