### PR TITLE
EVEREST-1927 | Do not allow changing storage size

### DIFF
--- a/internal/server/handlers/validation/database_cluster.go
+++ b/internal/server/handlers/validation/database_cluster.go
@@ -539,6 +539,11 @@ func (h *validateHandler) validateDatabaseClusterOnUpdate(
 		return fmt.Errorf("cannot scale down %d node cluster to 1. The operation is not supported", oldDB.Spec.Engine.Replicas)
 	}
 
+	// Do not allow updating storage size.
+	if dbc.Spec.Engine.Storage.Size.Cmp(oldDB.Spec.Engine.Storage.Size) != 0 {
+		return errCannotChangeStorageSize
+	}
+
 	if err := validateShardingOnUpdate(dbc, oldDB); err != nil {
 		return err
 	}

--- a/internal/server/handlers/validation/errors.go
+++ b/internal/server/handlers/validation/errors.go
@@ -15,6 +15,7 @@ var (
 	minCPUQuantity     = resource.MustParse("600m") //nolint:gochecknoglobals
 	minMemQuantity     = resource.MustParse("512M") //nolint:gochecknoglobals
 
+	errCannotChangeStorageSize       = errors.New("cannot change storage size")
 	errNotEnoughMemory               = fmt.Errorf("memory limits should be above %s", minMemQuantity.String())
 	errNotEnoughCPU                  = fmt.Errorf("CPU limits should be above %s", minCPUQuantity.String())
 	errNotEnoughDiskSize             = fmt.Errorf("storage size should be above %s", minStorageQuantity.String())


### PR DESCRIPTION
[![EVEREST-1927](https://badgen.net/badge/JIRA/EVEREST-1927/green)](https://jira.percona.com/browse/EVEREST-1927) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

With this change, by default, we will be blocking updates to the storage size.

Note that we shall be changing this behaviour individually for each DB engine in their respective PRs/feature builds. This allows for controlled testing.

[EVEREST-1927]: https://perconadev.atlassian.net/browse/EVEREST-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ