### PR TITLE
EVEREST-1878 | MongoDB storage scaling support

### DIFF
--- a/internal/server/handlers/validation/database_cluster.go
+++ b/internal/server/handlers/validation/database_cluster.go
@@ -540,7 +540,7 @@ func (h *validateHandler) validateDatabaseClusterOnUpdate(
 	}
 
 	// Do not allow updating storage size.
-	if dbc.Spec.Engine.Type != everestv1alpha1.DatabaseEnginePXC &&
+	if dbc.Spec.Engine.Type != everestv1alpha1.DatabaseEnginePSMDB &&
 		dbc.Spec.Engine.Storage.Size.Cmp(oldDB.Spec.Engine.Storage.Size) != 0 {
 		return errCannotChangeStorageSize
 	}

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources/resources-edit-modal.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/cards/resources/resources-edit-modal.tsx
@@ -44,7 +44,7 @@ const ResourcesEditModal = ({
         dbType={dbType}
         pairProxiesWithNodes={false}
         showSharding={dbType === DbType.Mongo}
-        disableDiskInput={!allowVolumeExpansion || dbType !== DbType.Mysql}
+        disableDiskInput={!allowVolumeExpansion || dbType !== DbType.Mongo}
         allowDiskInputUpdate={false}
         hideProxies={dbType === DbType.Mongo && !shardingEnabled}
       />


### PR DESCRIPTION
[![EVEREST-1878](https://badgen.net/badge/JIRA/EVEREST-1878/green)](https://jira.percona.com/browse/EVEREST-1878) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Most of the code needed for supporting MongoDB storage scaling is already a part of this PR: https://github.com/percona/everest/pull/1191

So we need to only make minor tweaks to this


[EVEREST-1878]: https://perconadev.atlassian.net/browse/EVEREST-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ