### PR TITLE
EVEREST-1883 update ubuntu images

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -30,7 +30,7 @@ jobs:
         may-fail: [ false ]
 
     continue-on-error: ${{ matrix.may-fail }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up Go release
@@ -206,7 +206,7 @@ jobs:
         may-fail: [ false ]
 
     name: API Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       PERCONA_VERSION_SERVICE_URL: https://check-dev.percona.com/versions/v1
     steps:
@@ -385,7 +385,7 @@ jobs:
         go-version: [ 1.24.x ]
         may-fail: [ false ]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       PERCONA_VERSION_SERVICE_URL: https://check-dev.percona.com/versions/v1
     steps:
@@ -467,7 +467,7 @@ jobs:
     needs: [ test, check, integration_tests_api, integration_tests_flows, integration_tests_cli]
     name: Merge Gatekeeper
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Run Merge Gatekeeper
         uses: upsidr/merge-gatekeeper@v1.2.1

--- a/.github/workflows/dev-fe-gatekeeper.yaml
+++ b/.github/workflows/dev-fe-gatekeeper.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   cache_pnpm:
     name: Cache PNPM
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
           commit_message: "chore: lint/format"
 
   permission_checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Get User Permission
         id: checkAccess
@@ -136,7 +136,7 @@ jobs:
     needs: [CI_checks, permission_checks, E2E_tests_workflow]
     name: Merge Gatekeeper
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Run Merge Gatekeeper
         uses: upsidr/merge-gatekeeper@v1.2.1

--- a/.github/workflows/feature-build.yaml
+++ b/.github/workflows/feature-build.yaml
@@ -79,7 +79,7 @@ jobs:
         may-fail: [ false ]
 
     continue-on-error: ${{ matrix.may-fail }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       TOOLS_PATH: "/opt/tools/bin"


### PR DESCRIPTION
[![EVEREST-1883](https://badgen.net/badge/JIRA/EVEREST-1883/green)](https://jira.percona.com/browse/EVEREST-1883) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Update ubuntu images**
---
**Problem:**
EVEREST-1883

The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025 == no workflow execution if there is runs-on: ubuntu-20.04

Let's use `ubuntu-latest` and do not return to the problem anymore

**Related pull requests**

- https://github.com/percona/everest-operator/pull/706
- https://github.com/percona/everest-catalog/pull/57

[EVEREST-1883]: https://perconadev.atlassian.net/browse/EVEREST-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ