### PR TITLE
EVEREST-1691 - Make PMM QAN test more stable for PSMDB

### DIFF
--- a/ui/apps/everest/.e2e/utils/db-wizard.ts
+++ b/ui/apps/everest/.e2e/utils/db-wizard.ts
@@ -240,7 +240,7 @@ export const populateAdvancedConfig = async (
         case 'psmdb':
           // we set operationProfiling for PMM QAN test
           inputParameters =
-            'systemLog:\n verbosity: 1\noperationProfiling:\n mode: all\n slowOpThresholdMs: 100\n rateLimit: 100';
+            'systemLog:\n verbosity: 1\noperationProfiling:\n mode: all\n slowOpThresholdMs: 2\n rateLimit: 5';
           break;
         case 'postgresql':
           inputParameters = 'log_connections = yes\nshared_buffers = 192MB';


### PR DESCRIPTION
[![EVEREST-1691](https://badgen.net/badge/JIRA/EVEREST-1691/green)](https://jira.percona.com/browse/EVEREST-1691) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This should add more queries to the PMM QAN for PSMDB so the test should be more stable especially for 1 node setup.

[EVEREST-1691]: https://perconadev.atlassian.net/browse/EVEREST-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ