### PR TITLE
EVEREST-107 increase Merge Gatekeeper timeout

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -475,6 +475,6 @@ jobs:
           self: Merge Gatekeeper
           token: ${{ secrets.GITHUB_TOKEN }}
           interval: 45
-          timeout: 300
+          timeout: 600
           ignored: "license/snyk (Percona Everest), security/snyk (Percona Everest)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/dev-fe-gatekeeper.yaml
+++ b/.github/workflows/dev-fe-gatekeeper.yaml
@@ -144,6 +144,6 @@ jobs:
           self: Merge Gatekeeper
           token: ${{ secrets.GITHUB_TOKEN }}
           interval: 45
-          timeout: 300
+          timeout: 600
           ignored: "license/snyk (Percona Github Org), security/snyk (Percona Github Org)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

At some point Merge Gatekeeper sometimes started to fail ([example](https://github.com/percona/everest/actions/runs/14029878948/job/39275855694)) with 
```
Error: context deadline exceeded
```
There was the timeout of 5 min, let's increase it.

[EVEREST-107]: https://perconadev.atlassian.net/browse/EVEREST-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ