### PR TITLE
[UI] EVEREST-1962 Fix: trigger validaton after setting monitoring instance value

### DIFF
--- a/ui/apps/everest/src/components/time-selection/time-selection.test.tsx
+++ b/ui/apps/everest/src/components/time-selection/time-selection.test.tsx
@@ -155,8 +155,10 @@ describe('TimeSelection', () => {
     );
   });
 
-  it('should render correctly for UTX+X timezone when monthly is selected', () => {
+  it('should render correctly for UTX+X timezone with or without DST when monthly is selected', () => {
     vi.stubEnv('TZ', 'Europe/Amsterdam');
+    const today = new Date();
+    const isDST = today.getMonth() > 1 && today.getDate() >= 30 ? true : false;
     render(
       <TestWrapper>
         <FormProviderWrapper>
@@ -174,7 +176,7 @@ describe('TimeSelection', () => {
 
     expect(screen.getByTestId('select-input-hour')).toHaveAttribute(
       'value',
-      '1'
+      isDST ? '2' : '1'
     );
     expect(screen.getByTestId('select-input-minute')).toHaveAttribute(
       'value',

--- a/ui/apps/everest/src/pages/database-form/database-form-body/steps/monitoring/monitoring.tsx
+++ b/ui/apps/everest/src/pages/database-form/database-form-body/steps/monitoring/monitoring.tsx
@@ -107,7 +107,8 @@ export const Monitoring = () => {
       if (monitoring && availableMonitoringInstances?.length) {
         setValue(
           DbWizardFormFields.monitoringInstance,
-          availableMonitoringInstances[0].name
+          availableMonitoringInstances[0].name,
+          { shouldValidate: true }
         );
       }
     }
@@ -118,7 +119,8 @@ export const Monitoring = () => {
     ) {
       setValue(
         DbWizardFormFields.monitoringInstance,
-        availableMonitoringInstances[0].name
+        availableMonitoringInstances[0].name,
+        { shouldValidate: true }
       );
     }
   }, [monitoring]);


### PR DESCRIPTION
[![EVEREST-1962](https://badgen.net/badge/JIRA/EVEREST-1962/green)](https://jira.percona.com/browse/EVEREST-1962) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The issue happened because of the new logic for the db form resolver: the schema validation happens before setting the monitoring value, and is not re-triggered properly.


https://github.com/user-attachments/assets/079d9131-6454-4d6c-a0fe-f2699a1315d3

[EVEREST-1962]: https://perconadev.atlassian.net/browse/EVEREST-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ