### PR TITLE
EVEREST-1866 - Add test for DB major/minor upgrade for PSMDB

### DIFF
--- a/ui/apps/everest/.e2e/constants.ts
+++ b/ui/apps/everest/.e2e/constants.ts
@@ -16,6 +16,12 @@ export enum EVEREST_CI_NAMESPACES {
   PG_ONLY = 'pg-only',
 }
 
+export const technologyMap: Record<string, string> = {
+  psmdb: "MongoDB",
+  pxc: "MySQL",
+  postgresql: "PostgreSQL",
+};
+
 export const getBucketNamespacesMap = (): BucketsNamespaceMap =>
   JSON.parse(EVEREST_BUCKETS_NAMESPACES_MAP);
 

--- a/ui/apps/everest/.e2e/constants.ts
+++ b/ui/apps/everest/.e2e/constants.ts
@@ -17,9 +17,9 @@ export enum EVEREST_CI_NAMESPACES {
 }
 
 export const technologyMap: Record<string, string> = {
-  psmdb: "MongoDB",
-  pxc: "MySQL",
-  postgresql: "PostgreSQL",
+  psmdb: 'MongoDB',
+  pxc: 'MySQL',
+  postgresql: 'PostgreSQL',
 };
 
 export const getBucketNamespacesMap = (): BucketsNamespaceMap =>

--- a/ui/apps/everest/.e2e/release/db-major-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/release/db-major-upgrade.e2e.ts
@@ -355,7 +355,7 @@ test.describe.configure({ retries: 0 });
               await page.getByTestId('form-dialog-upgrade').click();
               await page.goto('/databases');
               await waitForStatus(page, clusterName, 'Upgrading', 15000);
-              await waitForStatus(page, clusterName, 'Up', 1200000);
+              await waitForStatus(page, clusterName, 'Up', 600000);
               const technology = technologyMap[db] || 'Unknown';
               await expect(
                 page.getByText(`${technology} ${nextMajorVersion}`)
@@ -433,7 +433,7 @@ test.describe.configure({ retries: 0 });
               await page.getByTestId('form-dialog-upgrade').click();
               await page.goto('/databases');
               await waitForStatus(page, clusterName, 'Upgrading', 15000);
-              await waitForStatus(page, clusterName, 'Up', 300000);
+              await waitForStatus(page, clusterName, 'Up', 600000);
               const technology = technologyMap[db] || 'Unknown';
               await expect(
                 page.getByText(`${technology} ${nextDbMinorVersion}`)

--- a/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
@@ -67,7 +67,7 @@ test.describe.configure({ retries: 0 });
     },
     () => {
       test.skip(!shouldExecuteDBCombination(db, size));
-      test.describe.configure({ timeout: 1200000 });
+      test.describe.configure({ timeout: 720000 });
 
       const shSuffix = sharding ? '-sh' : '';
       const clusterName = `${db}-${size}${shSuffix}-upg`;
@@ -305,6 +305,7 @@ test.describe.configure({ retries: 0 });
         page,
         request,
       }) => {
+        test.setTimeout(2400000);
         let i = 0;
         let expectedResult: string[] = ['1', '2', '3'];
 

--- a/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
@@ -115,7 +115,7 @@ test.describe.configure({ retries: 0 });
               request,
               majorDBVersions[db][0]
             )
-          )[1];
+          )[0];
 
           if (process.env.DEBUG_TESTS) {
             console.log('Starting with version: ' + dbVersion);
@@ -255,45 +255,6 @@ test.describe.configure({ retries: 0 });
         await page.getByTestId('form-dialog-create').click();
 
         await waitForStatus(page, baseBackupName + '-1', 'Succeeded', 300000);
-      });
-
-      test(`Run first minor upgrade [${db} size ${size} sharding ${sharding}]`, async ({
-        page,
-        request,
-      }) => {
-        await test.step(`Upgrade to latest minor DB version`, async () => {
-          const nextDbMinorVersion = (
-            await getVersionServiceDBVersions(
-              db,
-              crVersion,
-              request,
-              majorDBVersions[db][0]
-            )
-          )[0];
-          if (process.env.DEBUG_TESTS) {
-            console.log('Upgrading to: ' + nextDbMinorVersion);
-          }
-          await page.goto('/databases');
-          await findDbAndClickRow(page, clusterName);
-          await page.getByTestId('upgrade-db-btn').click();
-          await expect(page.getByText('Upgrade DB version')).toBeVisible();
-          await expect(page.getByTestId('form-dialog-upgrade')).toBeDisabled();
-          await page.getByRole('combobox').click();
-          await page
-            .getByRole('option', { name: `${nextDbMinorVersion}` })
-            .click();
-          await expect(page.getByTestId('form-dialog-cancel')).toBeEnabled();
-          await page.getByTestId('form-dialog-upgrade').click();
-          await page.goto('/databases');
-          await waitForStatus(page, clusterName, 'Upgrading', 15000);
-          await waitForStatus(page, clusterName, 'Up', 600000);
-          const technology = technologyMap[db] || 'Unknown';
-          await expect(
-            page.getByText(`${technology} ${nextDbMinorVersion}`)
-          ).toBeVisible();
-          await findDbAndClickRow(page, clusterName);
-          await expect(page.getByTestId('upgrade-db-btn')).not.toBeVisible();
-        });
       });
 
       test(`Run major/minor upgrades [${db} size ${size} sharding ${sharding}]`, async ({

--- a/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
@@ -61,7 +61,7 @@ test.describe.configure({ retries: 0 });
   { db: 'psmdb', size: 3, sharding: true },
 ].forEach(({ db, size, sharding }) => {
   test.describe(
-    'Database major upgrade',
+    'Database upgrade',
     {
       tag: '@release',
     },

--- a/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
@@ -236,12 +236,7 @@ test.describe.configure({ retries: 0 });
       });
 
       test(`Setup MongoDB-specific sharding [${db} size ${size} sharding ${sharding}]`, async () => {
-        if (db !== 'psmdb' || !sharding) {
-          console.log(
-            'Not PSMDB with sharding enabled so skipping sharding collection.'
-          );
-          return;
-        }
+        test.skip(db !== 'psmdb' || !sharding);
         await configureMongoDBSharding(clusterName, namespace);
         await validateMongoDBSharding(clusterName, namespace, 't1');
         await validateMongoDBSharding(clusterName, namespace, 't2');

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -100,7 +100,8 @@ test.describe.configure({ retries: 0 });
             clusterName,
             db,
             storageClasses[0],
-            false
+            false,
+            null
           );
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -139,7 +139,8 @@ test.describe.configure({ retries: 0 });
             clusterName,
             db,
             storageClasses[0],
-            false
+            false,
+            null
           );
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -93,7 +93,8 @@ test.describe(
           clusterName,
           db,
           storageClasses[0],
-          false
+          false,
+          null
         );
       });
 

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -99,7 +99,8 @@ function getNextScheduleMinute(incrementMinutes: number): string {
             clusterName,
             db,
             storageClasses[0],
-            false
+            false,
+            null
           );
           await moveForward(page);
         });

--- a/ui/apps/everest/.e2e/utils/db-cluster.ts
+++ b/ui/apps/everest/.e2e/utils/db-cluster.ts
@@ -230,22 +230,3 @@ export const getDbAvailableUpgradeVersionK8S = async (
     return null;
   }
 };
-
-export const getDbNextLatestMajorVersion = async (
-  dbType: string,
-  namespace: string,
-  majorVersionRequested: string,
-  request: APIRequestContext,
-) => {
-  const operatorLongName = { psmdb: Operator.PSMDB, pxc: Operator.PXC, postgresql: Operator.PG }[dbType] || undefined;
-  const crVersion = await getDbOperatorVersionK8s(namespace, operatorLongName);
-
-  try {
-    const versions = getVersionServiceDBVersions(dbType, crVersion, request, majorVersionRequested);
-    const dbUpgradeVersion = versions[0];
-    return dbUpgradeVersion;
-  } catch (error) {
-    console.error('Error extracting database version:', error);
-    return null;
-  }
-};

--- a/ui/apps/everest/.e2e/utils/db-cluster.ts
+++ b/ui/apps/everest/.e2e/utils/db-cluster.ts
@@ -220,7 +220,12 @@ export const getDbAvailableUpgradeVersionK8S = async (
       : dbSplitVersion[0] + '.' + dbSplitVersion[1];
 
   try {
-    const versions = getVersionServiceDBVersions(dbType, crVersion, request, dbMajorVersion);
+    const versions = getVersionServiceDBVersions(
+      dbType,
+      crVersion,
+      request,
+      dbMajorVersion
+    );
     const dbUpgradeVersion = versions[0];
 
     // return latest version only if different than current one

--- a/ui/apps/everest/.e2e/utils/db-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/db-cmd-line.ts
@@ -253,6 +253,7 @@ export const insertTestDB = async (
     }
     case 'psmdb': {
       const jsonData = data.map((d) => `{ a: ${d} }`).join(', ');
+
       await queryPSMDB(
         cluster,
         namespace,
@@ -261,6 +262,7 @@ export const insertTestDB = async (
       );
       const result = await queryTestDB(cluster, namespace);
       const expected_result = expected.map((d) => `{"a":${d}}`).join(',');
+
       expect(result.trim()).toBe('[' + expected_result + ']');
       break;
     }

--- a/ui/apps/everest/.e2e/utils/db-wizard.ts
+++ b/ui/apps/everest/.e2e/utils/db-wizard.ts
@@ -96,7 +96,8 @@ export const populateBasicInformation = async (
   clusterName: string,
   dbType: string,
   storageClass: string,
-  mongoSharding: boolean = false
+  mongoSharding: boolean = false,
+  dbVersion: string
 ) => {
   if (namespace) {
     await page.getByTestId('k8s-namespace-autocomplete').click();
@@ -116,6 +117,11 @@ export const populateBasicInformation = async (
       await page.getByTestId('switch-input-sharding').click();
       await expect(page.getByTestId('switch-input-sharding')).toBeEnabled();
     }
+  }
+
+  if (dbVersion) {
+    await page.getByTestId('select-db-version-button').click();
+    await page.getByRole('option', { name: `${dbVersion}` }).click();
   }
 };
 

--- a/ui/apps/everest/.e2e/utils/generic.ts
+++ b/ui/apps/everest/.e2e/utils/generic.ts
@@ -26,17 +26,20 @@ export const checkError = async (response) => {
   expect(response.ok()).toBeTruthy();
 };
 
-export const getDbOperatorVersionK8s = async (namespace: string, operator: string) => {
+export const getDbOperatorVersionK8s = async (
+  namespace: string,
+  operator: string
+) => {
   try {
     const command = `kubectl get deployment --namespace ${namespace} ${operator} -o jsonpath="{.spec.template.spec.containers[0].image}"`;
     const output = execSync(command).toString();
-    const version = output.split(":")[1];
+    const version = output.split(':')[1];
     return version;
   } catch (error) {
     console.error(`Error executing command: ${error}`);
     throw error;
   }
-}
+};
 
 export const shouldExecuteDBCombination = (db: string, size: number) => {
   return (

--- a/ui/apps/everest/.e2e/utils/generic.ts
+++ b/ui/apps/everest/.e2e/utils/generic.ts
@@ -45,6 +45,18 @@ export const getVersionServiceURL = async () => {
   }
 };
 
+export const getDbOperatorVersionK8s = async (namespace: string, operator: string) => {
+  try {
+    const command = `kubectl get deployment --namespace ${namespace} ${operator} -o jsonpath="{.spec.template.spec.containers[0].image}"`;
+    const output = execSync(command).toString();
+    const version = output.split(":")[1];
+    return version;
+  } catch (error) {
+    console.error(`Error executing command: ${error}`);
+    throw error;
+  }
+}
+
 export const shouldExecuteDBCombination = (db: string, size: number) => {
   return (
     (SELECT_DB ? SELECT_DB === db : true) &&

--- a/ui/apps/everest/.e2e/utils/generic.ts
+++ b/ui/apps/everest/.e2e/utils/generic.ts
@@ -15,7 +15,6 @@
 
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
-import { everestFeatureBuildForUpgrade } from '@e2e/constants';
 
 const { SELECT_DB, SELECT_SIZE } = process.env;
 
@@ -25,24 +24,6 @@ export const checkError = async (response) => {
   }
   expect(response.status()).toBe(200);
   expect(response.ok()).toBeTruthy();
-};
-
-export const getVersionServiceURL = async () => {
-  if (
-    typeof everestFeatureBuildForUpgrade !== 'undefined' &&
-    everestFeatureBuildForUpgrade
-  ) {
-    return 'http://localhost:8081';
-  } else {
-    try {
-      const command = `kubectl get deployment everest-server --namespace everest-system -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='VERSION_SERVICE_URL')].value}"`;
-      const output = execSync(command).toString();
-      return output;
-    } catch (error) {
-      console.error(`Error executing command: ${error}`);
-      throw error;
-    }
-  }
 };
 
 export const getDbOperatorVersionK8s = async (namespace: string, operator: string) => {

--- a/ui/apps/everest/.e2e/utils/version-service.ts
+++ b/ui/apps/everest/.e2e/utils/version-service.ts
@@ -29,21 +29,21 @@ import { execSync } from 'child_process';
  * @throws Will throw an error if the `kubectl` command fails to execute.
  */
 export const getVersionServiceURL = async (): Promise<string> => {
-    if (
-      typeof everestFeatureBuildForUpgrade !== 'undefined' &&
-      everestFeatureBuildForUpgrade
-    ) {
-      return 'http://localhost:8081';
-    } else {
-      try {
-        const command = `kubectl get deployment everest-server --namespace everest-system -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='VERSION_SERVICE_URL')].value}"`;
-        const output = execSync(command).toString();
-        return output;
-      } catch (error) {
-        console.error(`Error executing command: ${error}`);
-        throw error;
-      }
+  if (
+    typeof everestFeatureBuildForUpgrade !== 'undefined' &&
+    everestFeatureBuildForUpgrade
+  ) {
+    return 'http://localhost:8081';
+  } else {
+    try {
+      const command = `kubectl get deployment everest-server --namespace everest-system -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='VERSION_SERVICE_URL')].value}"`;
+      const output = execSync(command).toString();
+      return output;
+    } catch (error) {
+      console.error(`Error executing command: ${error}`);
+      throw error;
     }
+  }
 };
 
 /**
@@ -59,37 +59,44 @@ export const getVersionServiceURL = async (): Promise<string> => {
  *
  * @throws Will log an error to the console if the request fails or the response is malformed.
  */
-export const getVersionServiceDBVersions = async (dbType: string, crVersion: string, request: APIRequestContext, majorVersion?: string): Promise<string[]> => {
-    const versions: string[] = [];
-    const vsKey = dbType === 'psmdb' ? 'mongod' : dbType;
-    const dbOperatorName = dbType === 'postgresql' ? 'pg-operator' : dbType + '-operator';
-    const versionServiceURL = await getVersionServiceURL();
+export const getVersionServiceDBVersions = async (
+  dbType: string,
+  crVersion: string,
+  request: APIRequestContext,
+  majorVersion?: string
+): Promise<string[]> => {
+  const versions: string[] = [];
+  const vsKey = dbType === 'psmdb' ? 'mongod' : dbType;
+  const dbOperatorName =
+    dbType === 'postgresql' ? 'pg-operator' : dbType + '-operator';
+  const versionServiceURL = await getVersionServiceURL();
 
-    try {
-        const response = await (
-          await request.get(
-            versionServiceURL +
-              `/versions/v1/${dbOperatorName}/${crVersion}`
-          )
-        ).json();
+  try {
+    const response = await (
+      await request.get(
+        versionServiceURL + `/versions/v1/${dbOperatorName}/${crVersion}`
+      )
+    ).json();
 
-        response.versions.forEach((versionEntry: any) => {
-            const dbVersions = versionEntry.matrix?.[vsKey];
-            if (dbVersions) {
-                for (const [version] of Object.entries(dbVersions)) {
-                    versions.push(version);
-                }
-            }
-        });
-        if (!Array.isArray(response?.versions)) return null;
-    
-        // Sort versions in descending order (latest first)
-        versions.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
-    
-        // Filter by major version if provided
-        return majorVersion ? versions.filter(version => version.startsWith(majorVersion)) : versions;
-      } catch (error) {
-        console.error('Error extracting database version:', error);
-        return null;
+    response.versions.forEach((versionEntry: any) => {
+      const dbVersions = versionEntry.matrix?.[vsKey];
+      if (dbVersions) {
+        for (const [version] of Object.entries(dbVersions)) {
+          versions.push(version);
+        }
       }
+    });
+    if (!Array.isArray(response?.versions)) return null;
+
+    // Sort versions in descending order (latest first)
+    versions.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+
+    // Filter by major version if provided
+    return majorVersion
+      ? versions.filter((version) => version.startsWith(majorVersion))
+      : versions;
+  } catch (error) {
+    console.error('Error extracting database version:', error);
+    return null;
+  }
 };

--- a/ui/apps/everest/.e2e/utils/version-service.ts
+++ b/ui/apps/everest/.e2e/utils/version-service.ts
@@ -1,0 +1,72 @@
+// everest
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { APIRequestContext } from '@playwright/test';
+import { everestFeatureBuildForUpgrade } from '@e2e/constants';
+import { execSync } from 'child_process';
+
+export const getVersionServiceURL = async () => {
+    if (
+      typeof everestFeatureBuildForUpgrade !== 'undefined' &&
+      everestFeatureBuildForUpgrade
+    ) {
+      return 'http://localhost:8081';
+    } else {
+      try {
+        const command = `kubectl get deployment everest-server --namespace everest-system -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='VERSION_SERVICE_URL')].value}"`;
+        const output = execSync(command).toString();
+        return output;
+      } catch (error) {
+        console.error(`Error executing command: ${error}`);
+        throw error;
+      }
+    }
+};
+
+export const getVersionServiceDBVersions = async (dbType: string, crVersion: string, request: APIRequestContext, majorVersion?: string): Promise<string[]> => {
+    const versions: string[] = [];
+    const vsKey = dbType === 'psmdb' ? 'mongod' : dbType;
+    const dbOperatorName = dbType === 'postgresql' ? 'pg-operator' : dbType + '-operator';
+    const versionServiceURL = await getVersionServiceURL();
+
+    try {
+        const response = await (
+          await request.get(
+            versionServiceURL +
+              `/versions/v1/${dbOperatorName}/${crVersion}`
+          )
+        ).json();
+
+        console.log(response);
+        response.versions.forEach((versionEntry: any) => {
+            const dbVersions = versionEntry.matrix?.[vsKey];
+            if (dbVersions) {
+                for (const [version] of Object.entries(dbVersions)) {
+                    versions.push(version);
+                }
+            }
+        });
+        if (!Array.isArray(response?.versions)) return null;
+    
+        // Sort versions in descending order (latest first)
+        versions.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    
+        // Filter by major version if provided
+        return majorVersion ? versions.filter(version => version.startsWith(majorVersion)) : versions;
+      } catch (error) {
+        console.error('Error extracting database version:', error);
+        return null;
+      }
+};

--- a/ui/apps/everest/src/components/time-selection/time-selection.test.tsx
+++ b/ui/apps/everest/src/components/time-selection/time-selection.test.tsx
@@ -158,7 +158,10 @@ describe('TimeSelection', () => {
   it('should render correctly for UTX+X timezone with or without DST when monthly is selected', () => {
     vi.stubEnv('TZ', 'Europe/Amsterdam');
     const today = new Date();
-    const isDST = today.getMonth() > 1 && today.getDate() >= 30 ? true : false;
+    const janOffset = new Date(today.getFullYear(), 0, 1).getTimezoneOffset();
+    const julOffset = new Date(today.getFullYear(), 6, 1).getTimezoneOffset();
+    const isDST = today.getTimezoneOffset() < Math.max(janOffset, julOffset);
+
     render(
       <TestWrapper>
         <FormProviderWrapper>


### PR DESCRIPTION
[![EVEREST-1866](https://badgen.net/badge/JIRA/EVEREST-1866/green)](https://jira.percona.com/browse/EVEREST-1866) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds a test for PSMDB database upgrade (major and minor) and it also covers MongoDB sharding.

The flow is following:
- start with lowest major version supported and latest minor version (eg. 6.0.19-16)
- do major upgrade to 7.0 non latest minor version (eg. 7.0.14-8)
- do minor upgrade to latest 7.0 version (eg. 7.0.15-9)
- do major upgrade to 8.0 (latest minor version since currently there is only one supported)

In the process we also create backups for each major version and check that data is available and consistent.

[EVEREST-1866]: https://perconadev.atlassian.net/browse/EVEREST-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ