### PR TITLE
EVEREST-1948 | fix bad component age display

### DIFF
--- a/ui/apps/everest/src/pages/db-cluster-details/components/components.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/components/components.tsx
@@ -21,7 +21,7 @@ import { Table } from '@percona/ui-lib';
 import { MRT_ColumnDef } from 'material-react-table';
 import { DBClusterComponent } from 'shared-types/components.types';
 import StatusField from 'components/status-field';
-import { format, formatDistanceToNowStrict, isValid } from 'date-fns';
+import { format, isValid, formatDuration, intervalToDuration } from 'date-fns';
 import {
   COMPONENT_STATUS,
   COMPONENT_STATUS_WEIGHT,
@@ -32,6 +32,7 @@ import { DATE_FORMAT } from 'consts';
 
 const Components = () => {
   const { dbClusterName, namespace = '' } = useParams();
+  const now = new Date();
 
   const { data: components = [], isLoading } = useDbClusterComponents(
     namespace,
@@ -82,7 +83,17 @@ const Components = () => {
               placement="right"
               arrow
             >
-              <div>{formatDistanceToNowStrict(date)}</div>
+              <div>
+                {formatDuration(
+                  intervalToDuration({
+                    start: date,
+                    end: now,
+                  }),
+                  {
+                    format: ['years', 'months', 'days', 'hours', 'minutes'],
+                  }
+                )}
+              </div>
             </Tooltip>
           ) : (
             ''

--- a/ui/apps/everest/src/pages/db-cluster-details/components/expanded-row/expanded-row.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/components/expanded-row/expanded-row.tsx
@@ -16,7 +16,7 @@
 import { Box, Tooltip, Typography, useTheme } from '@mui/material';
 import { MRT_ColumnDef, MRT_Row } from 'material-react-table';
 import { DBClusterComponent } from 'shared-types/components.types';
-import { format, formatDistanceToNowStrict } from 'date-fns';
+import { format, formatDuration, intervalToDuration } from 'date-fns';
 import {
   CONTAINER_STATUS,
   containerStatusToBaseStatus,
@@ -30,6 +30,7 @@ import { DATE_FORMAT } from 'consts';
 const ExpandedRow = ({ row }: { row: MRT_Row<DBClusterComponent> }) => {
   const { containers, name } = row.original;
   const theme = useTheme();
+  const now = new Date();
 
   const columns = useMemo<MRT_ColumnDef<Container>[]>(() => {
     return [
@@ -93,7 +94,16 @@ const ExpandedRow = ({ row }: { row: MRT_Row<DBClusterComponent> }) => {
                 variant="caption"
                 color={theme.palette.text.secondary}
               >
-                {formatDistanceToNowStrict(date)} ago{' '}
+                {formatDuration(
+                  intervalToDuration({
+                    start: date,
+                    end: now,
+                  }),
+                  {
+                    format: ['years', 'months', 'days', 'hours', 'minutes'],
+                  }
+                )}{' '}
+                ago{' '}
               </Typography>
             </Tooltip>
           ) : (


### PR DESCRIPTION
Moved from date-fns' `formatDistanceToNowStrict` to `formatDuration`.
Problem: `formatDistanceToNowStrict` has well defined intervals that might be misleading to users.
For example, a date from 89m ago reads as "1 hour", but 91m reads already as "2h", as per docs: https://date-fns.org/v4.1.0/docs/formatDistanceToNow

