### PR TITLE
EVEREST-1975 | [bugfix] DBengine min version preflight checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.27.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250328114816-9759fbd73b03
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250328115355-de03e1e1d5a6
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250331111537-4757a7ebe1dd
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -2249,8 +2249,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250328114816-9759fbd73b03 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250328114816-9759fbd73b03/go.mod h1:/sOqCv61zeH7QJNeRcQNnI7YTw+u+hCVPpK5xJOvt1w=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee h1:LtitxWyhBqCNjIZqdvsSEPBd2HPg11lDBlIExTQAbGQ=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20241212160532-0157f87a7eee/go.mod h1:zikIUTNTflfcth3ZJRqhvW8+7Jj38aVlg+wSV1jwnxo=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250328115355-de03e1e1d5a6 h1:gpIMrCdAazHWYrNk0PJjRcHa1h15iLkqz/SAx/ZDi5U=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250328115355-de03e1e1d5a6/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250331111537-4757a7ebe1dd h1:Oc6I5s+2+hMCFYF1V7yK1AVrUFyfcBGkSbPztyk/ytU=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250331111537-4757a7ebe1dd/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd h1:9RCUfPUxbdXuL/247r77DJmRSowDzA2xzZC9FpuLuUw=
 github.com/percona/percona-postgresql-operator v0.0.0-20241007204305-35d61aa5aebd/go.mod h1:ICbLstSO4zhYo+SFSciIWO9rLHQg29GJ1335L0tfhR0=
 github.com/percona/percona-server-mongodb-operator v1.19.1 h1:lqIC7V80bZPJwjeYLYl/WA+QVQMHo193uEAx5zyIg84=

--- a/internal/server/handlers/k8s/database_engine.go
+++ b/internal/server/handlers/k8s/database_engine.go
@@ -308,7 +308,7 @@ func preflightCheckDBEngineVersion(
 	if err != nil {
 		return false, "", err
 	}
-	return currentVersion.GreaterThanOrEqual(minVersion), minVersion.String(), nil
+	return currentVersion.GreaterThanOrEqual(minVersion), minVersion.Original(), nil
 }
 
 func (h *k8sHandler) getDBPostUpgradeTasks(

--- a/internal/server/handlers/k8s/database_engine_test.go
+++ b/internal/server/handlers/k8s/database_engine_test.go
@@ -111,6 +111,64 @@ func TestGetUpgradePreflightChecks(t *testing.T) {
 		assert.Equal(t, "Upgrade DB version to 0.5.0 or higher", pointer.Get(dbResult.Message))
 	})
 
+	t.Run("pending DB Engine upgrade [PG versioning]", func(t *testing.T) {
+		t.Parallel()
+
+		operatorVersion := "2.5.0"
+		targetVersion := "2.6.0"
+
+		// Setup mock
+		mockDBVersions := []string{"13.16", "14.12", "15.8", "16.4"}
+		versionService := versionservice.MockInterface{}
+		versionService.On(
+			"GetSupportedEngineVersions",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(mockDBVersions, nil)
+
+		dbs := []everestv1alpha1.DatabaseCluster{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-db",
+				Namespace: "test-namespace",
+			},
+			Spec: everestv1alpha1.DatabaseClusterSpec{
+				Engine: everestv1alpha1.Engine{
+					Version: "12.19",
+				},
+			},
+		}}
+		engine := everestv1alpha1.DatabaseEngine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-engine",
+				Namespace: "test-namespace",
+			},
+			Spec: everestv1alpha1.DatabaseEngineSpec{
+				Type: everestv1alpha1.DatabaseEnginePXC,
+			},
+			Status: everestv1alpha1.DatabaseEngineStatus{
+				OperatorVersion: operatorVersion,
+				PendingOperatorUpgrades: []everestv1alpha1.OperatorUpgrade{
+					{TargetVersion: targetVersion},
+				},
+			},
+		}
+
+		result, err := getUpgradePreflightChecksResult(ctx, dbs, upgradePreflightCheckArgs{
+			targetVersion:  targetVersion,
+			versionService: &versionService,
+			engine:         &engine,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, operatorVersion, result.currentVersion)
+		assert.Len(t, result.databases, 1)
+		dbResult := (result.databases)[0]
+		assert.Equal(t, "test-db", pointer.Get(dbResult.Name))
+		assert.Equal(t, api.UpgradeEngine, pointer.Get(dbResult.PendingTask))
+		assert.Equal(t, "Upgrade DB version to 13.16 or higher", pointer.Get(dbResult.Message))
+	})
+
 	t.Run("pending CRVersion update", func(t *testing.T) {
 		t.Parallel()
 		dbs := []everestv1alpha1.DatabaseCluster{{


### PR DESCRIPTION
[![EVEREST-1975](https://badgen.net/badge/JIRA/EVEREST-1975/green)](https://jira.percona.com/browse/EVEREST-1975) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Due to a bug in how we use the version library, PG DB versions are returned in an incorrect form. For example, `13.16` is parsed and returned as `13.16.0`, which is a non-existent version. This causes issues when trying to upgrade PG version during operator upgrades.

[EVEREST-1975]: https://perconadev.atlassian.net/browse/EVEREST-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ