### PR TITLE
EVEREST-1971 - Add additional configurations into init-deploy test

### DIFF
--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -49,9 +49,12 @@ test.describe.configure({ retries: 0 });
 [
   { db: 'psmdb', size: 1 },
   { db: 'psmdb', size: 3 },
+  { db: 'psmdb', size: 5 },
   { db: 'pxc', size: 1 },
   { db: 'pxc', size: 3 },
+  { db: 'pxc', size: 5 },
   { db: 'postgresql', size: 1 },
+  { db: 'postgresql', size: 2 },
   { db: 'postgresql', size: 3 },
 ].forEach(({ db, size }) => {
   test.describe(

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -348,7 +348,7 @@ test.describe.configure({ retries: 0 });
         }
         // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
         if (size != 1 || db != 'psmdb') {
-          await waitForStatus(page, clusterName, 'Initializing', 60000);
+          await waitForStatus(page, clusterName, 'Initializing', 120000);
         }
         await waitForStatus(page, clusterName, 'Up', 600000);
       });

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -149,7 +149,7 @@ test.describe.configure({ retries: 0 });
           if (size != 1 || db != 'psmdb') {
             await waitForStatus(page, clusterName, 'Initializing', 30000);
           }
-          await waitForStatus(page, clusterName, 'Up', 600000);
+          await waitForStatus(page, clusterName, 'Up', 720000);
         });
 
         await test.step('Check db cluster k8s object options', async () => {
@@ -338,7 +338,7 @@ test.describe.configure({ retries: 0 });
         if (size != 1 || db != 'psmdb') {
           await waitForStatus(page, clusterName, 'Initializing', 45000);
         }
-        await waitForStatus(page, clusterName, 'Up', 300000);
+        await waitForStatus(page, clusterName, 'Up', 360000);
       });
 
       test(`Restart cluster [${db} size ${size}]`, async ({ page }) => {
@@ -354,6 +354,7 @@ test.describe.configure({ retries: 0 });
       });
 
       test(`Edit cluster/scale up [${db} size ${size}]`, async ({ page }) => {
+        test.skip(size > 3);
         const newSize = size + 2;
         let customProxyTestId = 'toggle-button-proxies-custom';
 

--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -338,7 +338,7 @@ test.describe.configure({ retries: 0 });
         if (size != 1 || db != 'psmdb') {
           await waitForStatus(page, clusterName, 'Initializing', 45000);
         }
-        await waitForStatus(page, clusterName, 'Up', 360000);
+        await waitForStatus(page, clusterName, 'Up', 600000);
       });
 
       test(`Restart cluster [${db} size ${size}]`, async ({ page }) => {
@@ -350,7 +350,7 @@ test.describe.configure({ retries: 0 });
         if (size != 1 || db != 'psmdb') {
           await waitForStatus(page, clusterName, 'Initializing', 60000);
         }
-        await waitForStatus(page, clusterName, 'Up', 300000);
+        await waitForStatus(page, clusterName, 'Up', 600000);
       });
 
       test(`Edit cluster/scale up [${db} size ${size}]`, async ({ page }) => {


### PR DESCRIPTION
[![EVEREST-1971](https://badgen.net/badge/JIRA/EVEREST-1971/green)](https://jira.percona.com/browse/EVEREST-1971) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This adds 5 node clusters configuration for PSMDB/PXC and for PG it adds 2 node configuration into init-deploy.e2e.ts test.

[EVEREST-1971]: https://perconadev.atlassian.net/browse/EVEREST-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ