### PR TITLE
EVEREST-1975 | [bugfix] upgrade preflight checks for DB engine version

### DIFF
--- a/internal/server/handlers/k8s/database_engine.go
+++ b/internal/server/handlers/k8s/database_engine.go
@@ -312,13 +312,9 @@ func preflightCheckDBEngineVersion(
 			return false, "", err
 		}
 		if currentVersion.Segments()[0] > ver.Segments()[0] {
-			continue
+			continue // ignore if major version is less than the current major version.
 		}
-		if minSupportedMajVersion == nil {
-			minSupportedMajVersion = ver
-			continue
-		}
-		if ver.LessThan(minSupportedMajVersion) {
+		if minSupportedMajVersion == nil || ver.LessThan(minSupportedMajVersion) {
 			minSupportedMajVersion = ver
 		}
 	}

--- a/internal/server/handlers/k8s/database_engine_test.go
+++ b/internal/server/handlers/k8s/database_engine_test.go
@@ -111,7 +111,68 @@ func TestGetUpgradePreflightChecks(t *testing.T) {
 		assert.Equal(t, "Upgrade DB version to 0.5.0 or higher", pointer.Get(dbResult.Message))
 	})
 
-	t.Run("pending DB Engine upgrade [PG versioning]", func(t *testing.T) {
+	t.Run("pending minor version upgrade", func(t *testing.T) {
+		t.Parallel()
+
+		operatorVersion := "2.5.0"
+		targetVersion := "2.6.0"
+
+		// Setup mock
+		mockDBVersions := []string{"13.16", "14.12", "15.8", "16.4"}
+		versionService := versionservice.MockInterface{}
+		versionService.On(
+			"GetSupportedEngineVersions",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(mockDBVersions, nil)
+
+		dbs := []everestv1alpha1.DatabaseCluster{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-db",
+				Namespace: "test-namespace",
+			},
+			Spec: everestv1alpha1.DatabaseClusterSpec{
+				Engine: everestv1alpha1.Engine{
+					Version: "16.3",
+				},
+			},
+			Status: everestv1alpha1.DatabaseClusterStatus{
+				Status: everestv1alpha1.AppStateReady,
+			},
+		}}
+		engine := everestv1alpha1.DatabaseEngine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-engine",
+				Namespace: "test-namespace",
+			},
+			Spec: everestv1alpha1.DatabaseEngineSpec{
+				Type: everestv1alpha1.DatabaseEnginePXC,
+			},
+			Status: everestv1alpha1.DatabaseEngineStatus{
+				OperatorVersion: operatorVersion,
+				PendingOperatorUpgrades: []everestv1alpha1.OperatorUpgrade{
+					{TargetVersion: targetVersion},
+				},
+			},
+		}
+
+		result, err := getUpgradePreflightChecksResult(ctx, dbs, upgradePreflightCheckArgs{
+			targetVersion:  targetVersion,
+			versionService: &versionService,
+			engine:         &engine,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, operatorVersion, result.currentVersion)
+		assert.Len(t, result.databases, 1)
+		dbResult := (result.databases)[0]
+		assert.Equal(t, "test-db", pointer.Get(dbResult.Name))
+		assert.Equal(t, api.UpgradeEngine, pointer.Get(dbResult.PendingTask))
+		assert.Equal(t, "Upgrade DB version to 16.4 or higher", pointer.Get(dbResult.Message))
+	})
+
+	t.Run("pending major version upgrade", func(t *testing.T) {
 		t.Parallel()
 
 		operatorVersion := "2.5.0"
@@ -136,6 +197,9 @@ func TestGetUpgradePreflightChecks(t *testing.T) {
 				Engine: everestv1alpha1.Engine{
 					Version: "12.19",
 				},
+			},
+			Status: everestv1alpha1.DatabaseClusterStatus{
+				Status: everestv1alpha1.AppStateReady,
 			},
 		}}
 		engine := everestv1alpha1.DatabaseEngine{


### PR DESCRIPTION
[![EVEREST-1975](https://badgen.net/badge/JIRA/EVEREST-1975/green)](https://jira.percona.com/browse/EVEREST-1975) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As a part of the operator upgrade preflight checks, Everest checks if the given DB engine version is greater than or equal to the smallest available DB engine version in the target release. However, this code assumes that all available versions shall be of the same major version -- which does not hold true for PG. This leads to incomplete preflight checks, i.e, users are allowed to upgrade the operator even if the DB is in a version not supported by the next operator version.

For example, consider the following test case:

- Current PG version: 16.3
- Versions available in next PGO: ["13.16", "14.12", "15.8", "16.4"]

Expectation: Since 16.3 is not supported in the next version, we expect that the preflight check fail, prompting the user to upgrade to 16.4 first.

Actual: The code considers the entire list (rather than just 16.x), and since 16.3 > 13.16, the preflight check (wrongly) succeeds.

[EVEREST-1975]: https://perconadev.atlassian.net/browse/EVEREST-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ