### PR TITLE
EVEREST-1981 - Fix PG client issue and Initializing status

### DIFF
--- a/.github/postgresql-client.yaml
+++ b/.github/postgresql-client.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: postgresql-client
-          image: percona/percona-distribution-postgresql:16
+          image: percona/percona-distribution-postgresql:17
           imagePullPolicy: Always
           command:
           - sleep

--- a/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/release/db-upgrade.e2e.ts
@@ -199,7 +199,7 @@ test.describe.configure({ retries: 0 });
         // go to db list and check status
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
-          await waitForStatus(page, clusterName, 'Initializing', 15000);
+          await waitForStatus(page, clusterName, 'Initializing', 30000);
           await waitForStatus(page, clusterName, 'Up', 600000);
         });
 

--- a/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/demand-backup.e2e.ts
@@ -134,7 +134,7 @@ test.describe.configure({ retries: 0 });
         // go to db list and check status
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
-          await waitForStatus(page, clusterName, 'Initializing', 15000);
+          await waitForStatus(page, clusterName, 'Initializing', 30000);
           await waitForStatus(page, clusterName, 'Up', 600000);
         });
 

--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -201,7 +201,7 @@ test.describe.configure({ retries: 0 });
 
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
-          await waitForStatus(page, clusterName, 'Initializing', 15000);
+          await waitForStatus(page, clusterName, 'Initializing', 30000);
           await waitForStatus(page, clusterName, 'Up', 600000);
         });
 

--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -159,7 +159,7 @@ test.describe(
       // go to db list and check status
       await test.step('Check db list and status', async () => {
         await page.goto('/databases');
-        await waitForStatus(page, clusterName, 'Initializing', 15000);
+        await waitForStatus(page, clusterName, 'Initializing', 30000);
         await waitForStatus(page, clusterName, 'Up', 600000);
       });
 

--- a/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
+++ b/ui/apps/everest/.e2e/release/scheduled-backup.e2e.ts
@@ -141,7 +141,7 @@ function getNextScheduleMinute(incrementMinutes: number): string {
 
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
-          await waitForStatus(page, clusterName, 'Initializing', 15000);
+          await waitForStatus(page, clusterName, 'Initializing', 30000);
           await waitForStatus(page, clusterName, 'Up', 600000);
         });
 


### PR DESCRIPTION
[![EVEREST-1981](https://badgen.net/badge/JIRA/EVEREST-1981/green)](https://jira.percona.com/browse/EVEREST-1981) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We are having issue with PG client from version 16 with PG version 17 so it seems we need to use the newer client:
```
Error executing command: Error: Command failed: kubectl exec --namespace db-client postgresql-client-6f7b77ddd5-dlgng -- bash -c "PGPASSWORD='Uj+^j_1[K7*4o||d9SiCeW|J' psql -hpostgresql-3-dembkp-pgbouncer.everest-ui.svc -p5432 -Upostgres -dpostgres -t -q -c'\list'"
ERROR:  column d.daticulocale does not exist
LINE 8:   d.daticulocale as "ICU Locale",
          ^
HINT:  Perhaps you meant to reference the column "d.datlocale".
command terminated with exit code 1
```
This should also fix issue where we don't wait enough for `Initializing` status, probably because we added `Creating` status which is visible before.

[EVEREST-1981]: https://perconadev.atlassian.net/browse/EVEREST-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ