### PR TITLE
EVEREST-1985 handle pg PITR is always enabled

### DIFF
--- a/internal/server/handlers/k8s/database_cluster.go
+++ b/internal/server/handlers/k8s/database_cluster.go
@@ -188,7 +188,8 @@ func (h *k8sHandler) GetDatabaseClusterPitr(ctx context.Context, namespace, name
 	}
 
 	response := &api.DatabaseClusterPitr{}
-	if !databaseCluster.Spec.Backup.PITR.Enabled {
+	// for PG there is no such thing as enabling PITR, it is always enabled
+	if !databaseCluster.Spec.Backup.PITR.Enabled && databaseCluster.Spec.Engine.Type != everestv1alpha1.DatabaseEnginePostgresql {
 		return response, nil
 	}
 


### PR DESCRIPTION
[![EVEREST-1985](https://badgen.net/badge/JIRA/EVEREST-1985/green)](https://jira.percona.com/browse/EVEREST-1985) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

EVEREST-1985 

in https://github.com/percona/everest/pull/1096 we removed the `databaseCluster.Spec.Backup.Enabled` field and stopped checking it. However it was not taken into account that the pitr options for PG are always enabled (basically there is no such thing as "disable" pitr for PG), so in the rest of the code when we checking `if !databaseCluster.Spec.Backup.PITR.Enabled` we should exclude PG from consideration. 

Other option would be to handle it from the UI side and always send `databaseCluster.Spec.Backup.PITR.Enabled: true` for PG but that would be a bit weird if there is no such thing as disabling, so let's handle it from the BE side