### PR TITLE
POC: Integration tests using gunit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,7 @@ CHART_BRANCH ?= main
 update-dev-chart:
 	GOPROXY=direct go get -u -v github.com/percona/percona-helm-charts/charts/everest@$(CHART_BRANCH)
 	go mod tidy
+
+
+integration-tests:
+	go test -v ./integration/... -count=1 -timeout=20m

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250408103821-238475bf8caa
 	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250410143440-baa4adaf2c02
 	github.com/rodaine/table v1.3.0
+	github.com/smarty/gunit v1.5.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/unrolled/secure v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -2380,6 +2380,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smarty/gunit v1.5.0 h1:OmG6a/rgi7qCjlQis6VjXbvx/WqZ8I6xSlbfN4YB5MY=
+github.com/smarty/gunit v1.5.0/go.mod h1:uAeNibUD292KZRcg5OTy7lb6WR5++UC0BQOzNuiRzpU=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/integration/backup_storage_suite_test.go
+++ b/integration/backup_storage_suite_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/smarty/gunit"
+
+	"github.com/percona/everest/client"
+)
+
+type backupStorageTestSuite struct {
+	*gunit.Fixture
+
+	everestClient *client.Client
+	testNs        string
+}
+
+const defaultTestNs = "everest"
+
+func (s *backupStorageTestSuite) Setup() {
+	s.testNs = defaultTestNs
+	if ns, ok := os.LookupEnv("INTEGRATION_TEST_NAMESPACE"); ok {
+		s.testNs = ns
+	}
+	c, err := newEverestClient()
+	if err != nil {
+		panic(err)
+	}
+	s.everestClient = c
+}
+
+func newEverestClient() (*client.Client, error) {
+	apiToken, ok := os.LookupEnv("INTEGRATION_TEST_API_TOKEN")
+	if !ok {
+		return nil, fmt.Errorf("INTEGRATION_TEST_API_TOKEN is not set")
+	}
+
+	url, ok := os.LookupEnv("INTEGRATION_TEST_API_URL")
+	if !ok {
+		return nil, fmt.Errorf("INTEGRATION_TEST_API_URL is not set")
+	}
+
+	attachAPITokenReqModifier := func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiToken))
+		return nil
+	}
+
+	everestClient, err := client.NewClient(url,
+		client.WithRequestEditorFn(attachAPITokenReqModifier))
+	if err != nil {
+		return nil, err
+	}
+	return everestClient, nil
+}
+
+func TestBackupStorage(t *testing.T) {
+	gunit.Run(new(backupStorageTestSuite), t)
+}

--- a/integration/backup_storage_test.go
+++ b/integration/backup_storage_test.go
@@ -1,0 +1,139 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+
+	"github.com/AlekSi/pointer"
+	"github.com/smarty/gunit"
+
+	"github.com/percona/everest/client"
+)
+
+func newTestSuffix() string {
+	return fmt.Sprintf("%06d", rand.Intn(1000000))
+}
+
+func (s *backupStorageTestSuite) TestBasicAPIOperations() {
+	backupStorageName := "backup-storage-" + newTestSuffix()
+	s.Run("create backup storage success", func(f *gunit.Fixture) {
+		payload := client.CreateBackupStorageJSONRequestBody{
+			Type:        "s3",
+			Name:        backupStorageName,
+			Url:         pointer.To("http://custom-url"),
+			Description: pointer.To("Dev storage"),
+			BucketName:  "percona-test-backup-storage",
+			Region:      "us-east-2",
+			AccessKey:   "sdfs",
+			SecretKey:   "sdfsdfsd",
+		}
+
+		resp, err := s.everestClient.CreateBackupStorage(context.Background(), s.testNs, payload)
+		f.Assert(err == nil)
+		f.Assert(resp != nil)
+		f.Assert(resp.StatusCode == http.StatusCreated)
+
+		body, err := io.ReadAll(resp.Body)
+		f.Assert(err == nil)
+		f.Assert(body != nil)
+
+		var created client.BackupStorage
+		f.Assert(json.Unmarshal(body, &created) == nil)
+
+		f.AssertEqual(payload.Name, created.Name)
+		f.AssertEqual(string(payload.Type), string(created.Type))
+		f.AssertEqual(pointer.Get(payload.Url), pointer.Get(created.Url))
+		f.AssertEqual(pointer.Get(payload.Description), pointer.Get(created.Description))
+		f.AssertEqual(payload.BucketName, created.BucketName)
+		f.AssertEqual(payload.Region, created.Region)
+	})
+
+	s.Run("update backup storage success", func(f *gunit.Fixture) {
+		payload := client.UpdateBackupStorageJSONRequestBody{
+			Description: pointer.To("Updated storage"),
+		}
+
+		resp, err := s.everestClient.UpdateBackupStorage(context.Background(), s.testNs, backupStorageName, payload)
+		f.AssertEqual(err, nil)
+		f.AssertEqual(resp.StatusCode, http.StatusOK)
+
+		body, err := io.ReadAll(resp.Body)
+		f.AssertEqual(err, nil)
+		defer resp.Body.Close()
+
+		var parsed *client.BackupStorage
+		f.AssertEqual(json.Unmarshal(body, &parsed), nil)
+
+		f.AssertEqual(pointer.Get(payload.Description), pointer.Get(parsed.Description))
+	})
+
+	s.Run("list backup storage success", func(f *gunit.Fixture) {
+		resp, err := s.everestClient.ListBackupStorages(context.Background(), s.testNs)
+		f.Assert(err == nil)
+		f.Assert(resp.StatusCode == http.StatusOK)
+
+		body, err := io.ReadAll(resp.Body)
+		f.Assert(err == nil)
+		defer resp.Body.Close()
+
+		var parsed *client.BackupStoragesList
+		f.Assert(json.Unmarshal(body, &parsed) == nil)
+
+		f.Assert(len(*parsed) == 1)
+	})
+
+	s.Run("delete backup storage success", func(f *gunit.Fixture) {
+		resp, err := s.everestClient.DeleteBackupStorage(context.Background(), s.testNs, backupStorageName)
+		f.Assert(err == nil)
+		f.Assert(resp.StatusCode == http.StatusNoContent)
+
+		resp, err = s.everestClient.GetBackupStorage(context.Background(), s.testNs, backupStorageName)
+		f.Assert(err == nil)
+		f.Assert(resp.StatusCode == http.StatusNotFound)
+	})
+}
+
+func (s *backupStorageTestSuite) TestCreateFailures() {
+	testCases := []struct {
+		payload   []byte
+		errorText string
+	}{
+		{
+			payload:   []byte(`{}`),
+			errorText: "property \"name\" is missing",
+		},
+		{
+			payload: []byte(`{
+			"type": "s3", 
+			"name": "backup-storage", 
+			"bucketName": "percona-test-backup-storage", 
+			"region": "us-east-2", 
+			"accessKey": "ssdssd"}`),
+			errorText: "property \"secretKey\" is missing",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.errorText, func(f *gunit.Fixture) {
+			payload := bytes.NewBuffer(tc.payload)
+
+			resp, err := s.everestClient.CreateBackupStorageWithBody(context.Background(), s.testNs, "application/json", payload)
+			f.Assert(err == nil)
+			f.Assert(resp.StatusCode == http.StatusBadRequest)
+
+			body, err := io.ReadAll(resp.Body)
+			f.Assert(err == nil)
+			defer resp.Body.Close()
+
+			var parsed *client.Error
+			f.Assert(json.Unmarshal(body, &parsed) == nil)
+			f.Assert(strings.Contains(*parsed.Message, tc.errorText))
+		})
+	}
+}


### PR DESCRIPTION
The following environment variables need be set first:
- `INTEGRATION_TEST_API_URL`
- `INTEGRATION_TEST_API_TOKEN`
- `INTEGRATION_TEST_NAMESPACE` (defaults to using `everest`)

Run the tests using `make integration-tests`