### PR TITLE
Fix psmdb-sharding.e2e.ts to not run when different DB selected

### DIFF
--- a/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
+++ b/ui/apps/everest/.e2e/release/psmdb-sharding.e2e.ts
@@ -45,6 +45,7 @@ import {
 } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
 import { checkDBMetrics, checkQAN } from '@e2e/utils/monitoring-instance';
+import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
 let token: string;
 
@@ -59,6 +60,7 @@ test.describe(
     tag: '@release',
   },
   () => {
+    test.skip(!shouldExecuteDBCombination(db, size));
     test.describe.configure({ timeout: 720000 });
 
     const clusterName = `${db}-${size}-shard`;


### PR DESCRIPTION
Fix psmdb-sharding E2E test to not run if different database than PSMDB selected.