### PR TITLE
EVEREST-1106 Check built-in user existence on every request

### DIFF
--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -48,7 +48,10 @@ const (
 	SessionManagerClaimsIssuer = "everest"
 )
 
-var errExtractSub = errors.New("could not extract sub")
+var (
+	errExtractSub = errors.New("could not extract sub")
+	errExtractIss = errors.New("could not extract iss")
+)
 
 // Manager provides functionality for creating and managing JWT tokens.
 type Manager struct {
@@ -218,8 +221,12 @@ func extractUsername(token *jwt.Token) (string, bool, error) {
 	if !ok {
 		return "", false, errExtractSub
 	}
+	iss, ok := content.Payload["iss"].(string)
+	if !ok {
+		return "", false, errExtractIss
+	}
 	username := strings.TrimSuffix(sub, ":login")
-	return username, len(sub) > len(username), nil
+	return username, iss == SessionManagerClaimsIssuer, nil
 }
 
 // ClientCacheOptions returns the cache options for the session manager k8s client.

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/AlekSi/pointer"
@@ -32,6 +33,10 @@ import (
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/percona/everest/api"
 	"github.com/percona/everest/pkg/accounts"
@@ -43,6 +48,8 @@ const (
 	SessionManagerClaimsIssuer = "everest"
 )
 
+var errExtractSub = errors.New("could not extract sub")
+
 // Manager provides functionality for creating and managing JWT tokens.
 type Manager struct {
 	accountManager accounts.Interface
@@ -53,6 +60,24 @@ type Manager struct {
 
 // Option is a function that modifies a SessionManager.
 type Option func(*Manager)
+
+func (mgr *Manager) IsBlocked(ctx context.Context, token *jwt.Token) (bool, error) {
+	username, isBuiltInUser, err := extractUsername(token)
+	if err != nil {
+		return false, fmt.Errorf("failed to extract username: %w", err)
+	}
+	// for the built-in users check if the account exists
+	if isBuiltInUser {
+		_, err := mgr.accountManager.Get(ctx, username)
+		if err != nil {
+			if errors.Is(err, accounts.ErrAccountNotFound) {
+				return true, nil
+			}
+			return false, err
+		}
+	}
+	return mgr.Blocklist.IsBlocked(ctx, token)
+}
 
 // New creates a new session manager with the given options.
 func New(ctx context.Context, l *zap.SugaredLogger, options ...Option) (*Manager, error) {
@@ -178,4 +203,38 @@ func (mgr *Manager) BlocklistMiddleWare(skipperFunc func() (echomiddleware.Skipp
 			return next(c)
 		}
 	}, nil
+}
+
+// extractUsername returns
+// - the current username from the token
+// - a bool flag that indicates whereas it's a built-in auth user
+// - an error
+func extractUsername(token *jwt.Token) (string, bool, error) {
+	content, err := extractContent(token)
+	if err != nil {
+		return "", false, err
+	}
+	sub, ok := content.Payload["sub"].(string)
+	if !ok {
+		return "", false, errExtractSub
+	}
+	username := strings.TrimSuffix(sub, ":login")
+	return username, len(sub) > len(username), nil
+}
+
+// ClientCacheOptions returns the cache options for the session manager k8s client.
+// To avoid overwhelming k8s API with requests, the client should cache the accounts secret,
+// because every authenticated API request checks the secret.
+// It also defines a rule for the system namespace which gets requested otherwise the ByObject won't allow to read the ns.
+func ClientCacheOptions() *cache.Options {
+	return &cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Field: fields.SelectorFromSet(fields.Set{"metadata.name": common.EverestAccountsSecretName}),
+			},
+			&corev1.Namespace{}: {
+				Field: fields.SelectorFromSet(fields.Set{"metadata.name": common.SystemNamespace}),
+			},
+		},
+	}
 }

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractUsername(t *testing.T) {
+	type tcase struct {
+		name          string
+		token         *jwt.Token
+		error         error
+		username      string
+		isBuiltInUser bool
+	}
+	tcases := []tcase{
+		{
+			name:          "oidc user",
+			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "some_user@email.com"}),
+			error:         nil,
+			username:      "some_user@email.com",
+			isBuiltInUser: false,
+		},
+		{
+			name:          "built-in user",
+			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "admin:login"}),
+			error:         nil,
+			username:      "admin",
+			isBuiltInUser: true,
+		},
+		{
+			name:          "no sub in token",
+			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{}),
+			error:         errExtractSub,
+			username:      "",
+			isBuiltInUser: false,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			username, isBuiltInUser, err := extractUsername(tc.token)
+			assert.Equal(t, username, tc.username)
+			assert.Equal(t, isBuiltInUser, tc.isBuiltInUser)
+			assert.Equal(t, tc.error, err)
+		})
+	}
+}

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -18,14 +18,14 @@ func TestExtractUsername(t *testing.T) {
 	tcases := []tcase{
 		{
 			name:          "oidc user",
-			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "some_user@email.com"}),
+			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "some_user@email.com", "iss": "external_issuer"}),
 			error:         nil,
 			username:      "some_user@email.com",
 			isBuiltInUser: false,
 		},
 		{
 			name:          "built-in user",
-			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "admin:login"}),
+			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "admin:login", "iss": "everest"}),
 			error:         nil,
 			username:      "admin",
 			isBuiltInUser: true,
@@ -34,6 +34,13 @@ func TestExtractUsername(t *testing.T) {
 			name:          "no sub in token",
 			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{}),
 			error:         errExtractSub,
+			username:      "",
+			isBuiltInUser: false,
+		},
+		{
+			name:          "no iss in token",
+			token:         jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "smth"}),
+			error:         errExtractIss,
 			username:      "",
 			isBuiltInUser: false,
 		},


### PR DESCRIPTION
[![EVEREST-1106](https://badgen.net/badge/JIRA/EVEREST-1106/green)](https://jira.percona.com/browse/EVEREST-1106) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

EVEREST-1106

For the deleted built-in users, their access token was still valid until its natural expiration time.
To fix this, Everest server from now on checks if the user exists for every authenticated request for a built-in user. To avoid overloading k8s API with requests, Everest server uses a separate controller-runtime client with cache enabled for the needed resources.

[EVEREST-1106]: https://perconadev.atlassian.net/browse/EVEREST-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ