### PR TITLE
EVEREST-107 | fix integration test failures

### DIFF
--- a/.github/workflows/dev-be-ci.yaml
+++ b/.github/workflows/dev-be-ci.yaml
@@ -258,7 +258,7 @@ jobs:
         id: minikube
         with:
           cpus: 2
-          memory: 2000m
+          memory: 4000m
           addons: registry
           insecure-registry: 'localhost:5000'
 

--- a/api-tests/tests/pxc-clusters.spec.ts
+++ b/api-tests/tests/pxc-clusters.spec.ts
@@ -51,7 +51,7 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
         replicas: 1,
         version: recommendedVersion,
         storage: {
-          size: '25G',
+          size: '25Gi',
         },
         resources: {
           cpu: '1',


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[EVEREST-107]: https://perconadev.atlassian.net/browse/EVEREST-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Looking at the recent integration test failures, we're getting 2 kinds of errors frequently:

#### 1. Connection refused errors

Going through the events of the Everest server pods, it seems that the pod starts fine, things run okay for a while and then the pod crashes.

**Solution:** We will need a deeper investigation of which change lead to a sudden increase in memory usage, but increasing the size of the minikube cluster from 2G to 4G resolves the issue

#### 2. PXC single node test failures

It seems that the `create/edit/delete pxc single node cluster` test frequently fails with the the error `db operations are not allowed in current db state: resizingVolumes` even though there are no disk updates taking place in that test. Moreover, it seems that the DB goes into `resizingVolumes` state soon after creation.

Upon further investigation, it was discovered that the PXC operator actually tries a disk resize operation on the cluster and soon fails because Minikube does not support this. This is because we specify the size in `G` (not `Gi` like the UI), and the PXC operator performs a round-off operation to convert it to `G`. This rounding off leads to it incorrectly thinking that there is a disk resizing. 

**Solution:** Use `Gi` like the UI. Whether this needs to be improved in PXC operator requires a deeper investigation, but for now this will unblock our CI.
