### PR TITLE
EVEREST-2029,EVEREST-2021 Check password creation time

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -82,6 +82,8 @@ const (
 	EverestAdminUser = "admin"
 	// EverestAdminRole is the name of the admin role.
 	EverestAdminRole = EverestRBACRolePrefix + "admin"
+	// EverestAccountsFileName is the key used in everest-accounts secret
+	EverestAccountsFileName = "users.yaml"
 
 	// EverestSettingsConfigMapName is the name of the Everest settings ConfigMap.
 	EverestSettingsConfigMapName = "everest-settings"

--- a/pkg/kubernetes/accounts.go
+++ b/pkg/kubernetes/accounts.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	usersFile = "users.yaml"
 	// We set this annotation on the secret to indicate which passwords are stored in plain text.
 	insecurePasswordAnnotation = "insecure-password/%s"
 	insecurePasswordValueTrue  = "true"
@@ -76,7 +75,7 @@ func (a *configMapsClient) listAllAccounts(ctx context.Context) (map[string]*acc
 	if err != nil {
 		return nil, err
 	}
-	if err := yaml.Unmarshal(secret.Data[usersFile], result); err != nil {
+	if err := yaml.Unmarshal(secret.Data[common.EverestAccountsFileName], result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -141,7 +140,7 @@ func (a *configMapsClient) insertOrUpdateAccount(
 	}
 
 	accounts := make(map[string]*accounts.Account)
-	if err := yaml.Unmarshal(secret.Data[usersFile], &accounts); err != nil {
+	if err := yaml.Unmarshal(secret.Data[common.EverestAccountsFileName], &accounts); err != nil {
 		return err
 	}
 
@@ -154,7 +153,7 @@ func (a *configMapsClient) insertOrUpdateAccount(
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte)
 	}
-	secret.Data[usersFile] = data
+	secret.Data[common.EverestAccountsFileName] = data
 
 	annotations := secret.GetAnnotations()
 	if annotations == nil {
@@ -200,7 +199,7 @@ func (a *configMapsClient) Delete(ctx context.Context, username string) error {
 	if err != nil {
 		return err
 	}
-	secret.Data[usersFile] = data
+	secret.Data[common.EverestAccountsFileName] = data
 	if _, err := a.k.UpdateSecret(ctx, secret); err != nil {
 		return err
 	}
@@ -214,7 +213,7 @@ func (a *configMapsClient) Verify(ctx context.Context, username, password string
 	}
 
 	users := make(map[string]*accounts.Account)
-	if err := yaml.Unmarshal(secret.Data[usersFile], users); err != nil {
+	if err := yaml.Unmarshal(secret.Data[common.EverestAccountsFileName], users); err != nil {
 		return err
 	}
 	user, found := users[username]

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -256,7 +256,7 @@ func extractCreationTime(token *jwt.Token) (*time.Time, error) {
 	if !ok {
 		return nil, errExtractIssueTime
 	}
-	parsedTime := time.Unix(int64(issTS), 0)
+	parsedTime := time.Unix(int64(issTS), 0).UTC()
 	return &parsedTime, nil
 }
 

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -1,10 +1,22 @@
 package session
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/AlekSi/pointer"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/kubernetes"
 )
 
 func TestExtractUsername(t *testing.T) {
@@ -54,5 +66,182 @@ func TestExtractUsername(t *testing.T) {
 			assert.Equal(t, isBuiltInUser, tc.isBuiltInUser)
 			assert.Equal(t, tc.error, err)
 		})
+	}
+}
+
+func TestExtractIssueTime(t *testing.T) {
+	type tcase struct {
+		name  string
+		token *jwt.Token
+		error error
+		time  *time.Time
+	}
+	tcases := []tcase{
+		{
+			name:  "no iat field",
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{}),
+			error: errExtractIssueTime,
+			time:  nil,
+		},
+		{
+			name:  "wrong iat field",
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iat": "sdfssfsf"}),
+			error: errExtractIssueTime,
+			time:  nil,
+		},
+		{
+			name:  "valid iat field",
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iat": float64(1747060325)}),
+			error: nil,
+			time:  pointer.To[time.Time](time.Date(2025, 5, 12, 19, 32, 5, 0, time.Local)),
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			time, err := extractCreationTime(tc.token)
+			assert.Equal(t, tc.time, time)
+			assert.Equal(t, tc.error, err)
+		})
+	}
+}
+
+func TestIsBlocked(t *testing.T) {
+	type tcase struct {
+		name      string
+		token     *jwt.Token
+		isBlocked bool
+		error     error
+		usersFile string
+	}
+	tcases := []tcase{
+		{
+			name:      "token issue date is older than password last edit date",
+			isBlocked: true,
+			error:     nil,
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"iat": float64(1747058324), // token creation time is 1 second earlier than the password timestamp
+				"sub": "test:login",
+				"iss": SessionManagerClaimsIssuer,
+			}),
+			usersFile: `test:
+  enabled: true
+  capabilities:
+  - login
+  passwordMtime: "2025-05-12T18:58:45+05:00"`, // timestamp is 1747058325
+		},
+		{
+			// this case covers:
+			// - creating users with the same name as the deleted users
+			// - changed password
+			name:      "token issue date is younger than password last edit date",
+			isBlocked: false,
+			error:     nil,
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"iat": float64(1747058326), // token creation time is 1 second later than the password timestamp
+				"sub": "test:login",
+				"iss": SessionManagerClaimsIssuer,
+			}),
+			usersFile: `test:
+  enabled: true
+  capabilities:
+  - login
+  passwordMtime: "2025-05-12T18:58:45+05:00"`, // timestamp is 1747058325
+		},
+		{
+			name:      "default admin user without the passwordMtime set",
+			isBlocked: false,
+			error:     nil,
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"iat": float64(1847058325),
+				"sub": "admin:login",
+				"iss": SessionManagerClaimsIssuer,
+			}),
+			usersFile: `admin:
+  enabled: true
+  capabilities:
+  - login`,
+		},
+		{
+			name: "account not found - block the request",
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"iat": float64(1847058325),
+				"sub": "unknown_account:login",
+				"iss": SessionManagerClaimsIssuer,
+			}),
+			error:     nil,
+			isBlocked: true,
+			usersFile: `test:
+  enabled: true
+  capabilities:
+  - login
+  passwordMtime: "2025-05-12T18:58:45+05:00"`,
+		},
+		{
+			// other error cases are covered by unit tests for specific functions
+			name:      "error parse passwordMtime",
+			token:     jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iat": float64(1847058325), "sub": "test:login", "iss": SessionManagerClaimsIssuer}), // ts is earlier than the password time
+			error:     errors.New(`parsing time "some weird string" as "2006-01-02T15:04:05Z07:00": cannot parse "some weird string" as "2006"`),
+			isBlocked: false,
+			usersFile: `test:
+  enabled: true
+  capabilities:
+  - login
+  passwordMtime: "some weird string"`,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			manager, err := mockManager(ctx, tc.usersFile, "")
+			assert.NoError(t, err)
+			isBlocked, err := manager.IsBlocked(ctx, tc.token)
+			if tc.error != nil {
+				assert.EqualError(t, err, tc.error.Error())
+			}
+			assert.Equal(t, tc.isBlocked, isBlocked)
+		})
+	}
+}
+
+func mockManager(ctx context.Context, usersFile, blocklistContent string) (*Manager, error) {
+	l := zap.NewNop().Sugar()
+
+	blocklistSecret := getBlockListSecretTemplate(blocklistContent)
+	usersSecret := userSecret(usersFile)
+
+	objs := []ctrlclient.Object{blocklistSecret, usersSecret}
+	mockClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.CreateScheme())
+	mockClient.WithObjects(objs...)
+
+	k := kubernetes.NewEmpty(l).WithKubernetesClient(mockClient.Build())
+
+	bl, err := mockNewBlocklist(ctx, l, k)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		accountManager: k.Accounts(),
+		signingKey:     nil,
+		Blocklist:      bl,
+		l:              l,
+	}, nil
+}
+
+func userSecret(file string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.EverestAccountsSecretName,
+			Namespace: common.SystemNamespace,
+		},
+		Data: map[string][]byte{
+			common.EverestAccountsFileName: []byte(file),
+		},
 	}
 }

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -93,7 +93,7 @@ func TestExtractIssueTime(t *testing.T) {
 			name:  "valid iat field",
 			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iat": float64(1747060325)}),
 			error: nil,
-			time:  pointer.To[time.Time](time.Date(2025, 5, 12, 19, 32, 5, 0, time.Local)),
+			time:  pointer.To[time.Time](time.Date(2025, 5, 12, 14, 32, 5, 0, time.UTC)),
 		},
 	}
 


### PR DESCRIPTION
[![EVEREST-2029](https://badgen.net/badge/JIRA/EVEREST-2029/green)](https://jira.percona.com/browse/EVEREST-2029) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem:**
- EVEREST-2029: in https://github.com/percona/everest/pull/1339 Everest started to check the built-in users existence on every request to restrict the API access for tokens issued for already deleted built-in users. However it's not enough. Since the built-in users names do not have unique identifiers, if one deletes a user and creates another user with the same name, the token from the deleted user becomes valid again until its expiration time. 
- EVEREST-2021: in case the built-in user's password has changed, the issued before the change tokens still remain valid until their expiration time. 

**Solution:**
Everest stores the date of the last edit for the built-in user's passwords. Both problems are solved by comparing the token issue date with the password last edit date - if the token is older, then it's considered invalid. 

[EVEREST-2029]: https://perconadev.atlassian.net/browse/EVEREST-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ