### PR TITLE
EVEREST-1981 - Skip service type check if cluster size not equal to 3

### DIFF
--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -187,6 +187,8 @@ test.describe.configure({ retries: 0 });
       });
 
       test(`Check service type is LoadBalancer [${db} size ${size}]`, async () => {
+        test.skip(size !== 3);
+
         let resourceName: string;
 
         switch (db) {


### PR DESCRIPTION
[![EVEREST-1981](https://badgen.net/badge/JIRA/EVEREST-1981/green)](https://jira.percona.com/browse/EVEREST-1981) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The test currently fails for 1 and 5 node clusters since we only enable external access for 3 node clusters.

[EVEREST-1981]: https://perconadev.atlassian.net/browse/EVEREST-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ