### PR TITLE
Add CODE_OF_CONDUCT.md referencing Percona Community guidelines

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Percona Everest Code of Conduct
+
+All Percona Products follow the [Percona Community Code of Conduct](https://github.com/percona/community/blob/main/content/contribute/coc.md).
+
+If you notice any unacceptable behavior, let us know as soon as possible by writing to [community-team@percona.com](mailto:community-team@percona.com).  
+We will respond within 48 hours.


### PR DESCRIPTION
Add CODE_OF_CONDUCT.md to align with the Percona Community Code of Conduct and make it visible on GitHub. Helps promote a respectful and inclusive environment.