### PR TITLE
Optional Tilt FE build

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -67,7 +67,10 @@ export EVEREST_CHART_DIR=<path to github.com/percona/percona-helm-charts>/charts
 
 2. Set namespaces for the Everest components:
 
-Copy file dev/config.yaml.example to dev/config.yaml and set the needed DB namespaces that will be created automatically.
+Copy file dev/config.yaml.example to dev/config.yaml and:
+
+- Set the needed DB namespaces that will be created automatically.
+- (Mostly for FE devs) If you want to disable the Tilt frontend build, save time and avoid FE rebuilds (and, therefore, BE rebuilds), keeping the dev flow of using Vite, set `enableFrontend: false`
 
 3. (Optional) If you want to test a specific version of a given DB operator you can set the following environment variables in .env file or in the terminal:
 ```sh

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -15,6 +15,10 @@ config_yaml=read_yaml('config.yaml')
 load('ext://dotenv', 'dotenv')
 
 local_env_file='{0}/.env'.format(config.main_dir)
+
+enable_frontend = config_yaml.get('enableFrontendBuild', True)
+print('Frontend Build enabled: {0}'.format(enable_frontend))
+
 if os.path.exists(local_env_file):
     print ('Loading local .env file={0}'.format(local_env_file))
     dotenv(fn=local_env_file)
@@ -552,32 +556,33 @@ k8s_resource(
 ############ Everest ############
 #################################
 
-# Build frontend
-local_resource(
-    'frontend-init',
-    'make -C {0} init'.format(frontend_dir),
-    deps=[
-        '{0}/package.json'.format(frontend_dir),
-    ],
-    labels=["everest"],
-)
+if enable_frontend:
+  # Build frontend
+  local_resource(
+      'frontend-init',
+      'make -C {0} init'.format(frontend_dir),
+      deps=[
+          '{0}/package.json'.format(frontend_dir),
+      ],
+      labels=["everest"],
+  )
 
-local_resource(
-  'frontend-build',
-  'make -C {0} build EVEREST_OUT_DIR={1}/public/dist'.format(frontend_dir, backend_dir),
-  deps=[
-      '{0}/apps'.format(frontend_dir),
-  ],
-  ignore=[
-    '{0}/apps/*/dist'.format(frontend_dir),
-    '{0}/**/.e2e'.format(frontend_dir),
-    '{0}/**/.turbo'.format(frontend_dir),
-  ],
-  resource_deps = [
-    'frontend-init',
-  ],
-  labels=["everest"]
-)
+  local_resource(
+    'frontend-build',
+    'make -C {0} build EVEREST_OUT_DIR={1}/public/dist'.format(frontend_dir, backend_dir),
+    deps=[
+        '{0}/apps'.format(frontend_dir),
+    ],
+    ignore=[
+      '{0}/apps/*/dist'.format(frontend_dir),
+      '{0}/**/.e2e'.format(frontend_dir),
+      '{0}/**/.turbo'.format(frontend_dir),
+    ],
+    resource_deps = [
+      'frontend-init',
+    ],
+    labels=["everest"]
+  )
 
 # Live update the Everest container without generating a new pod
 everest_build_target='build'
@@ -628,6 +633,10 @@ local_resource(
     labels=["everest"],
 )
 
+backend_build_resource_deps = ['backend-generate']
+if enable_frontend:
+    backend_build_resource_deps.append('frontend-build')
+
 local_resource(
     'backend-build',
     '{0} make -C {1} {2}'.format(everest_backend_build_env, backend_dir, everest_build_target),
@@ -647,10 +656,7 @@ local_resource(
         '{0}/**/mocks'.format(backend_dir),
         '{0}/**/*_test.go'.format(backend_dir),
     ],
-    resource_deps = [
-        'frontend-build',
-        'backend-generate',
-    ],
+    resource_deps=backend_build_resource_deps,
     labels=["everest"]
 )
 

--- a/dev/config.yaml.example
+++ b/dev/config.yaml.example
@@ -1,4 +1,5 @@
 # Copy this file to config.yaml in dev/ directory and set the values as needed.
+enableFrontendBuild: true
 namespaces:
   # List of DB namespaces that will be created automatically
   - name: my-special-place


### PR DESCRIPTION
Add `enableFrontendBuild` to `dev/config.yaml` (`true` by default).
This is useful for FE devs, as we don't rely on Tilt's FE build to develop and, therefore, don't need double the resources rebuilding FE+BE when we do a change.