### PR TITLE
[UI] Add ImportFailed status based on dbCluster.status.conditions

### DIFF
--- a/ui/apps/everest/src/pages/databases/DbClusterView.tsx
+++ b/ui/apps/everest/src/pages/databases/DbClusterView.tsx
@@ -93,7 +93,10 @@ export const DbClusterView = () => {
             statusMap={DB_CLUSTER_STATUS_TO_BASE_STATUS}
             defaultIcon={PendingIcon}
           >
-            {beautifyDbClusterStatus(cell.getValue<DbClusterStatus>())}
+            {beautifyDbClusterStatus(
+              cell.getValue<DbClusterStatus>(),
+              cell.row.original?.raw.status?.conditions || []
+            )}
           </StatusField>
         ),
       },

--- a/ui/apps/everest/src/pages/databases/DbClusterView.utils.ts
+++ b/ui/apps/everest/src/pages/databases/DbClusterView.utils.ts
@@ -19,6 +19,7 @@ import { Messages } from './dbClusterView.messages';
 import { DbClusterTableElement } from './dbClusterView.types';
 import { Backup, BackupStatus } from 'shared-types/backups.types';
 import { isProxy } from 'utils/db';
+import { DbErrorType } from 'shared-types/dbErrors.types';
 
 const DB_CLUSTER_STATUS_HUMANIFIED: Record<DbClusterStatus, string> = {
   [DbClusterStatus.ready]: Messages.statusProvider.up,
@@ -35,8 +36,20 @@ const DB_CLUSTER_STATUS_HUMANIFIED: Record<DbClusterStatus, string> = {
   [DbClusterStatus.importing]: Messages.statusProvider.importing,
 };
 
-export const beautifyDbClusterStatus = (status: DbClusterStatus): string =>
-  DB_CLUSTER_STATUS_HUMANIFIED[status] || Messages.statusProvider.creating;
+export const beautifyDbClusterStatus = (
+  status: DbClusterStatus,
+  conditions?: { type: string }[]
+): string => {
+  if (
+    status === DbClusterStatus.error &&
+    conditions?.some((c) => c.type === DbErrorType.ImportFailed)
+  ) {
+    return Messages.statusProvider.importFailed;
+  }
+  return (
+    DB_CLUSTER_STATUS_HUMANIFIED[status] || Messages.statusProvider.creating
+  );
+};
 
 export const convertDbClusterPayloadToTableFormat = (
   data: DbClusterForNamespaceResult[]

--- a/ui/apps/everest/src/pages/databases/dbClusterView.messages.tsx
+++ b/ui/apps/everest/src/pages/databases/dbClusterView.messages.tsx
@@ -28,6 +28,7 @@ export const Messages = {
     creating: 'Creating',
     upgrading: 'Upgrading',
     importing: 'Importing',
+    importFailed: 'Import Failed',
   },
   lastBackup: {
     warningTooltip: 'Check your backups page for more info',

--- a/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/db-errors/constants.ts
+++ b/ui/apps/everest/src/pages/db-cluster-details/cluster-overview/db-errors/constants.ts
@@ -1,9 +1,9 @@
 import { DbErrorType } from 'shared-types/dbErrors.types';
 
-const humanizedErrorMessages: Record<DbErrorType, string> = {
+const humanizedErrorMessages: Partial<Record<DbErrorType, string>> = {
   [DbErrorType.VolumeResizeFailed]:
     'An error occurred when resizing your cluster.',
 };
 
 export const humanizeDbError = (type: DbErrorType): string =>
-  humanizedErrorMessages[type];
+  humanizedErrorMessages[type] || '';

--- a/ui/apps/everest/src/pages/db-cluster-details/db-cluster-details.tsx
+++ b/ui/apps/everest/src/pages/db-cluster-details/db-cluster-details.tsx
@@ -72,7 +72,8 @@ const WithPermissionDetails = ({
               statusMap={DB_CLUSTER_STATUS_TO_BASE_STATUS}
             >
               {beautifyDbClusterStatus(
-                dbCluster?.status?.status || DbClusterStatus.creating
+                dbCluster?.status?.status || DbClusterStatus.creating,
+                dbCluster?.status?.conditions || []
               )}
             </StatusField>
             <DbActions showStatusActions={true} dbCluster={dbCluster!} />

--- a/ui/apps/everest/src/pages/settings/namespaces/namespace-details/cluster-status-table.tsx
+++ b/ui/apps/everest/src/pages/settings/namespaces/namespace-details/cluster-status-table.tsx
@@ -129,7 +129,10 @@ const ClusterStatusTable = ({
             status={cell.getValue<DbClusterStatus>()}
             statusMap={DB_CLUSTER_STATUS_TO_BASE_STATUS}
           >
-            {beautifyDbClusterStatus(cell.getValue<DbClusterStatus>())}
+            {beautifyDbClusterStatus(
+              cell.getValue<DbClusterStatus>(),
+              cell.row?.original.db?.status?.conditions || []
+            )}
           </StatusField>
         ),
       },

--- a/ui/apps/everest/src/shared-types/dbErrors.types.ts
+++ b/ui/apps/everest/src/shared-types/dbErrors.types.ts
@@ -1,4 +1,5 @@
 enum DbErrorType {
   VolumeResizeFailed = 'VolumeResizeFailed',
+  ImportFailed = 'ImportFailed',
 }
 export { DbErrorType };


### PR DESCRIPTION
[![EVEREST-2006](https://badgen.net/badge/JIRA/EVEREST-2006/green)](https://jira.percona.com/browse/EVEREST-2006) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We want to be able to tell if the import failed based on `dbCluster.status.conditions`

1. error state and no .status.conditions then show the DB as Down :red_circle:
2. error state and a .status.conditions that indicates an import failure (exact error TBD) show a new state called Import Failed :red_circle: 

Example of cluster status with import failed: 

```
...
status: {
        conditions: [{ type: "ImportFailed" }],
        status: "error",
        ...
      },

```