### PR TITLE
Adjust dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,27 +5,55 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "go"
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "go"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "docker"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "github_actions"
   - package-ecosystem: "npm"
     directory: "/api-tests"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "javascript"
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "javascript"
   - package-ecosystem: "npm"
     directory: "/cli-tests"
     schedule:
       interval: "weekly"
+    labels:
+      - "auto-update-base"
+      - "dependencies"
+      - "javascript"


### PR DESCRIPTION
Add `auto-update-base` label on PRs that are created by dependabot