### PR TITLE
EVEREST-1693 re-enable 1-node PSMDB tests

### DIFF
--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -189,10 +189,7 @@ const zephyrMap: Record<string, string> = {
 
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
-          // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
-          if (size != 1 || db != 'psmdb') {
-            await waitForStatus(page, clusterName, 'Initializing', 30000);
-          }
+		  await waitForStatus(page, clusterName, 'Initializing', 30000);
           await waitForStatus(page, clusterName, 'Up', 720000);
         });
 
@@ -424,10 +421,7 @@ const zephyrMap: Record<string, string> = {
         page,
       }) => {
         await resumeDbCluster(page, clusterName);
-        // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
-        if (size != 1 || db != 'psmdb') {
-          await waitForStatus(page, clusterName, 'Initializing', 45000);
-        }
+		await waitForStatus(page, clusterName, 'Initializing', 45000);
         await waitForStatus(page, clusterName, 'Up', 600000);
       });
 
@@ -439,10 +433,7 @@ const zephyrMap: Record<string, string> = {
         if (size != 1 && db != 'postgresql') {
           await waitForStatus(page, clusterName, 'Stopping', 45000);
         }
-        // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
-        if (size != 1 || db != 'psmdb') {
-          await waitForStatus(page, clusterName, 'Initializing', 120000);
-        }
+		await waitForStatus(page, clusterName, 'Initializing', 120000);
         await waitForStatus(page, clusterName, 'Up', 600000);
       });
 
@@ -502,10 +493,7 @@ const zephyrMap: Record<string, string> = {
 
         await test.step('Wait for cluster status', async () => {
           await page.goto('databases');
-          // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
-          if (size != 1 || db != 'psmdb') {
-            await waitForStatus(page, clusterName, 'Initializing', 60000);
-          }
+		  await waitForStatus(page, clusterName, 'Initializing', 60000);
           await waitForStatus(page, clusterName, 'Up', 300000);
         });
       });


### PR DESCRIPTION
After integrating with PSMDB operator v1.20.1, EVEREST-1693 is now fixed so we can re-enable the 1-node PSMDB tests.