### PR TITLE
EVEREST-2210 Fix session blockList for MS Entra

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/operator-framework/api v0.32.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20250730111243-bce9d869cde5
+	github.com/operator-framework/api v0.33.0
+	github.com/percona/everest-operator v0.6.0-dev1.0.20250806115327-b206083bb00f
 	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250801102351-5e60893d3d85
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -910,8 +910,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/operator-framework/api v0.32.0 h1:LZSZr7at3NrjsjwQVNsYD+04o5wMq75jrR0dMYiIIH8=
-github.com/operator-framework/api v0.32.0/go.mod h1:OGJo6HUYxoQwpGaLr0lPJzSek51RiXajJSSa8Jzjvp8=
+github.com/operator-framework/api v0.33.0 h1:Tdu9doXz6Key2riIiP3/JPahHEgFBXAqyWQN4kOITS8=
+github.com/operator-framework/api v0.33.0/go.mod h1:sEh1VqwQCJUj+l/rKNWPDEJdFNAbdTu8QcM+x+wdYYo=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
@@ -924,8 +924,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250730111243-bce9d869cde5 h1:hqIG4CrOavse4jDeweVvExsDZxHk+XcQ3hJU53jdRJY=
-github.com/percona/everest-operator v0.6.0-dev1.0.20250730111243-bce9d869cde5/go.mod h1:ECT8AkdjGFm43LrNjDhWcrowVjQxvKZtMIqQ6qEAr0A=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250806115327-b206083bb00f h1:2FU1b/kffY9eYFYgo80JCQht+MUhTFKOQJ56hBshSNA=
+github.com/percona/everest-operator v0.6.0-dev1.0.20250806115327-b206083bb00f/go.mod h1:fqf/M+zbnlSYYoditNBTBKwRrL0YaX3n3syKrEWOjLw=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe h1:CPO2T7ADauXJEXjwflAVYGRSZ/fKVVP12jE/Iy/1b7k=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe/go.mod h1:HRKf8nO4SqtNJ1oNzfY3THcwIsjGTWGBF3rNz1TwA9c=
 github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250801102351-5e60893d3d85 h1:dPPdciaIy93AaILTx4lCNEyvLF+XGcY/mliSzw6tVOs=

--- a/internal/server/handlers/k8s/kubernetes.go
+++ b/internal/server/handlers/k8s/kubernetes.go
@@ -90,7 +90,7 @@ func (h *k8sHandler) GetSettings(ctx context.Context) (*api.Settings, error) {
 	}
 	config, err := settings.OIDCConfig()
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, errors.New("cannot parse OIDC raw config"))
 	}
 	return &api.Settings{
 		OidcConfig: api.OIDCConfig{

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -105,7 +105,7 @@ func (e *EverestServer) securityHeaders() echo.MiddlewareFunc {
 		connectSrc = append(connectSrc, issuer)
 		connectSrc = append(connectSrc, oidcProvider.TokenURL)
 		if oidcProvider.OriginalIssuer != oidcProvider.Issuer {
-			// Is appears that original issuerUrl provided by user for OIDC configuration is not always
+			// It appears that original issuerUrl provided by user for OIDC configuration is not always
 			// the same as the one fetched from the OIDC provider's .well-known/openid-configuration (Microsoft Entra case).
 			// Need to add original issuer URL provided by user, otherwise there will be issues with browser login using SSO.
 			origIssuer, _ := url.JoinPath(oidcProvider.OriginalIssuer, oidc.WellKnownPath)

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -100,9 +101,16 @@ func (e *EverestServer) securityHeaders() echo.MiddlewareFunc {
 	useTLS := e.config.TLSCertsPath != ""
 	connectSrc := []string{CSPSelf}
 	if oidcProvider != nil {
-		issuer := strings.TrimRight(oidcProvider.Issuer, "/")
-		connectSrc = append(connectSrc, issuer+oidc.WellKnownPath)
+		issuer, _ := url.JoinPath(oidcProvider.Issuer, oidc.WellKnownPath)
+		connectSrc = append(connectSrc, issuer)
 		connectSrc = append(connectSrc, oidcProvider.TokenURL)
+		if oidcProvider.OriginalIssuer != oidcProvider.Issuer {
+			// Is appears that original issuerUrl provided by user for OIDC configuration is not always
+			// the same as the one fetched from the OIDC provider's .well-known/openid-configuration (Microsoft Entra case).
+			// Need to add original issuer URL provided by user, otherwise there will be issues with browser login using SSO.
+			origIssuer, _ := url.JoinPath(oidcProvider.OriginalIssuer, oidc.WellKnownPath)
+			connectSrc = append(connectSrc, origIssuer)
+		}
 	}
 
 	cspBuilder := cspbuilder.Builder{

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -80,7 +80,7 @@ func NewProviderConfig(ctx context.Context, issuer string) (ProviderConfig, erro
 		return ProviderConfig{}, fmt.Errorf("failed to unmarshal json response: %w", err)
 	}
 
-	// Is appears that issuerUrl provided by user is not always
+	// It appears that issuerUrl provided by user is not always
 	// the same as the one fetched from the OIDC provider's .well-known/openid-configuration (Microsoft Entra case).
 	// Need to store the original issuer URL too.
 	result.OriginalIssuer = issuer

--- a/pkg/session/blocklist_test.go
+++ b/pkg/session/blocklist_test.go
@@ -17,12 +17,15 @@ package session
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -39,7 +42,7 @@ func TestShortenToken(t *testing.T) {
 	}
 	tcases := []tcase{
 		{
-			name: "valid",
+			name: "valid jti",
 			claims: jwt.MapClaims{
 				"jti": "9d1c1f98-a479-41e3-8939-c7cb3edefa",
 				"exp": float64(331743679478),
@@ -48,12 +51,22 @@ func TestShortenToken(t *testing.T) {
 			error:          nil,
 		},
 		{
-			name: "no jti",
+			// "uti" is used by Microsoft Entra ID instead of "jti" claim
+			name: "valid uti",
+			claims: jwt.MapClaims{
+				"uti": "9d1c1f98-a479-41e3-8939-c7cb3edefa",
+				"exp": float64(331743679478),
+			},
+			shortenedToken: "9d1c1f98-a479-41e3-8939-c7cb3edefa331743679478",
+			error:          nil,
+		},
+		{
+			name: "no jti or uti",
 			claims: jwt.MapClaims{
 				"exp": float64(331743679478),
 			},
 			shortenedToken: "",
-			error:          errExtractJti,
+			error:          errExtractTokenID,
 		},
 		{
 			name: "no exp",
@@ -104,14 +117,24 @@ func TestExtractContent(t *testing.T) {
 			error: nil,
 		},
 		{
-			name:  "valid with payload",
+			name:  "valid with payload - jti claim",
 			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)}),
 			result: &JWTContent{
 				Payload: map[string]interface{}{"exp": float64(331743679478), "jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a"},
 			},
 			error: nil,
 		},
+		{
+			// "uti" is used by Microsoft Entra ID instead of "jti" claim
+			name:  "valid with payload - uti claim",
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"uti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)}),
+			result: &JWTContent{
+				Payload: map[string]interface{}{"exp": float64(331743679478), "uti": "9d1c1f98-a479-41e3-8939-c7cb3e049a"},
+			},
+			error: nil,
+		},
 	}
+
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -123,90 +146,286 @@ func TestExtractContent(t *testing.T) {
 }
 
 func TestBlocklist_Block(t *testing.T) {
-	mockClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.CreateScheme())
+	type tcase struct {
+		name    string
+		token   *jwt.Token
+		tokenID string
+		error   error
+	}
+
+	tokenUnsupportedClaims := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{})
+	tcases := []tcase{
+		{
+			name:    "empty token",
+			token:   nil,
+			tokenID: "",
+			error:   errEmptyToken,
+		},
+		{
+			name:    "unsupported claims",
+			token:   tokenUnsupportedClaims,
+			tokenID: "",
+			error:   errUnsupportedClaim(tokenUnsupportedClaims.Claims),
+		},
+		{
+			name:    "valid empty payload",
+			token:   jwt.New(jwt.SigningMethodHS256),
+			tokenID: "",
+			error:   errExtractTokenID,
+		},
+		{
+			name:    "valid with payload - jti claim",
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)}),
+			tokenID: "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478",
+			error:   nil,
+		},
+		{
+			// "uti" is used by Microsoft Entra ID instead of "jti" claim
+			name:    "valid with payload - uti claim",
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"uti": "keQ6r7TMsEikaoCHni2bAA", "exp": float64(331743679478)}),
+			tokenID: "keQ6r7TMsEikaoCHni2bAA331743679478",
+			error:   nil,
+		},
+	}
+
 	l := zap.NewNop().Sugar()
-	k := kubernetes.NewEmpty(l).WithKubernetesClient(mockClient.Build())
-
 	ctx := context.Background()
-	jwt := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)})
 
-	// check there is no blocklist secret before the blocklist creation
-	secret, err := k.GetSecret(ctx, ctrlclient.ObjectKey{
-		Name:      common.EverestBlocklistSecretName,
-		Namespace: common.SystemNamespace,
-	})
-	assert.True(t, k8serrors.IsNotFound(err))
-	assert.Nil(t, secret)
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.CreateScheme())
+			k := kubernetes.NewEmpty(l).WithKubernetesClient(mockClient.Build())
 
-	b, err := mockNewBlocklist(ctx, l, k)
-	assert.NoError(t, err)
+			// check there is no blocklist secret before the blocklist creation
+			secret, err := k.GetSecret(ctx, ctrlclient.ObjectKey{
+				Name:      common.EverestBlocklistSecretName,
+				Namespace: common.SystemNamespace,
+			})
+			assert.True(t, k8serrors.IsNotFound(err))
+			assert.Nil(t, secret)
 
-	// blocklist secret appears after the blocklist creation
-	secret, err = k.GetSecret(ctx, ctrlclient.ObjectKey{
-		Name:      common.EverestBlocklistSecretName,
-		Namespace: common.SystemNamespace,
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, secret)
-	assert.Equal(t, "", secret.StringData[dataKey])
+			b, err := mockNewBlocklist(ctx, l, k)
+			assert.NoError(t, err)
 
-	// block the token from the context and check the secret has been changed accordingly
-	err = b.Block(ctx, jwt)
-	assert.NoError(t, err)
+			// blocklist secret appears after the blocklist creation
+			secret, err = k.GetSecret(ctx, ctrlclient.ObjectKey{
+				Name:      common.EverestBlocklistSecretName,
+				Namespace: common.SystemNamespace,
+			})
+			assert.NoError(t, err)
+			assert.NotNil(t, secret)
+			assert.Equal(t, "", secret.StringData[dataKey])
 
-	secret, err = k.GetSecret(ctx, ctrlclient.ObjectKey{
-		Name:      common.EverestBlocklistSecretName,
-		Namespace: common.SystemNamespace,
-	})
-	assert.NoError(t, err)
-	// the mocked client does not do this StringData -> Data transformation in Secrets which the actual k8a API do, so
-	// we only check the StringData field
-	assert.Equal(t, "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478", secret.StringData[dataKey])
+			// block the token from the context and check the secret has been changed accordingly
+			err = b.Block(ctx, tc.token)
+			if tc.error != nil {
+				assert.Equal(t, tc.error, err)
+				return
+			}
 
-	// deleting secret to test the backoff
-	err = k.DeleteSecret(ctx, secret)
-	assert.NoError(t, err)
+			assert.NoError(t, err)
 
-	// after deleting secret - try to block again, get the NotFound error
-	err = b.Block(ctx, jwt)
-	assert.Equal(t, true, k8serrors.IsNotFound(err))
+			secret, err = k.GetSecret(ctx, ctrlclient.ObjectKey{
+				Name:      common.EverestBlocklistSecretName,
+				Namespace: common.SystemNamespace,
+			})
+			assert.NoError(t, err)
+			// the mocked client does not do this StringData -> Data transformation in Secrets which the actual k8a API do, so
+			// we only check the StringData field
+			assert.Equal(t, tc.tokenID, secret.StringData[dataKey])
+
+			// deleting secret to test the backoff
+			err = k.DeleteSecret(ctx, secret)
+			assert.NoError(t, err)
+
+			// after deleting secret - try to block again, get the NotFound error
+			err = b.Block(ctx, tc.token)
+			assert.Equal(t, true, k8serrors.IsNotFound(err))
+		})
+	}
 }
 
 func TestBlocklist_IsBlocked(t *testing.T) {
-	secret := getBlockListSecretTemplate("the-blocked-jti331743679478")
-	// when writing Secrets, the mocked client does not do this StringData -> Data transformation which the actual k8a API do,
-	// so we set the Data field manually
-	secret.Data = map[string][]byte{dataKey: []byte("the-blocked-jti331743679478")}
-	objs := []ctrlclient.Object{secret}
+	type tcase struct {
+		name    string
+		objs    []ctrlclient.Object
+		token   *jwt.Token
+		tokenID string
+		error   error
+		blocked bool
+	}
 
-	mockClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.CreateScheme())
-	mockClient.WithObjects(objs...)
+	tokenUnsupportedClaims := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{})
+	tcases := []tcase{
+		{
+			name:    "empty token",
+			token:   nil,
+			objs:    []ctrlclient.Object{},
+			tokenID: "",
+			error:   errors.Join(errEmptyToken, errShortenToken),
+			blocked: false,
+		},
+		{
+			name:    "unsupported claims",
+			token:   tokenUnsupportedClaims,
+			objs:    []ctrlclient.Object{},
+			tokenID: "",
+			error:   errors.Join(errUnsupportedClaim(tokenUnsupportedClaims.Claims), errShortenToken),
+			blocked: false,
+		},
+		{
+			name:    "valid empty payload",
+			token:   jwt.New(jwt.SigningMethodHS256),
+			objs:    []ctrlclient.Object{},
+			tokenID: "",
+			error:   errors.Join(errExtractTokenID, errShortenToken),
+			blocked: false,
+		},
+		{
+			name:    "empty list - not blocked valid with payload - jti claim",
+			objs:    []ctrlclient.Object{},
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)}),
+			tokenID: "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478",
+			error:   nil,
+			blocked: false,
+		},
+		{
+			name: "non-empty list - not blocked valid with payload - jti claim",
+			objs: []ctrlclient.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.EverestBlocklistSecretName,
+						Namespace: common.SystemNamespace,
+					},
+					StringData: map[string]string{
+						dataKey: "some-another-jti331743679478",
+					},
+					Data: map[string][]byte{
+						dataKey: []byte("some-another-jti331743679478"),
+					},
+				},
+			},
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)}),
+			tokenID: "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478",
+			error:   nil,
+			blocked: false,
+		},
+		{
+			name: "blocked valid with payload - jti claim",
+			objs: []ctrlclient.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.EverestBlocklistSecretName,
+						Namespace: common.SystemNamespace,
+					},
+					StringData: map[string]string{
+						dataKey: "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478",
+					},
+					Data: map[string][]byte{
+						dataKey: []byte("9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478"),
+					},
+				},
+			},
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "9d1c1f98-a479-41e3-8939-c7cb3e049a", "exp": float64(331743679478)}),
+			tokenID: "9d1c1f98-a479-41e3-8939-c7cb3e049a331743679478",
+			error:   nil,
+			blocked: true,
+		},
+		{
+			// "uti" is used by Microsoft Entra ID instead of "jti" claim
+			name:    "empty list - not blocked valid with payload - uti claim",
+			objs:    []ctrlclient.Object{},
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"uti": "keQ6r7TMsEikaoCHni2bAA", "exp": float64(331743679478)}),
+			tokenID: "keQ6r7TMsEikaoCHni2bAA331743679478",
+			error:   nil,
+			blocked: false,
+		},
+		{
+			// "uti" is used by Microsoft Entra ID instead of "jti" claim
+			name: "non-empty list - not blocked valid with payload - uti claim",
+			objs: []ctrlclient.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.EverestBlocklistSecretName,
+						Namespace: common.SystemNamespace,
+					},
+					StringData: map[string]string{
+						dataKey: "some-another-jti331743679478",
+					},
+					Data: map[string][]byte{
+						dataKey: []byte("some-another-jti331743679478"),
+					},
+				},
+			},
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"uti": "keQ6r7TMsEikaoCHni2bAA", "exp": float64(331743679478)}),
+			tokenID: "keQ6r7TMsEikaoCHni2bAA331743679478",
+			error:   nil,
+			blocked: false,
+		},
+		{
+			// "uti" is used by Microsoft Entra ID instead of "jti" claim
+			name: "blocked valid with payload - uti claim",
+			objs: []ctrlclient.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.EverestBlocklistSecretName,
+						Namespace: common.SystemNamespace,
+					},
+					StringData: map[string]string{
+						dataKey: "keQ6r7TMsEikaoCHni2bAA331743679478",
+					},
+					Data: map[string][]byte{
+						dataKey: []byte("keQ6r7TMsEikaoCHni2bAA331743679478"),
+					},
+				},
+			},
+			token:   jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"uti": "keQ6r7TMsEikaoCHni2bAA", "exp": float64(331743679478)}),
+			tokenID: "keQ6r7TMsEikaoCHni2bAA331743679478",
+			error:   nil,
+			blocked: true,
+		},
+	}
+
 	l := zap.NewNop().Sugar()
-	k := kubernetes.NewEmpty(l).WithKubernetesClient(mockClient.Build())
+	ctx := context.Background()
 
-	t.Run("blocked token in context", func(t *testing.T) {
-		ctx := context.Background()
-		jwt := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "the-blocked-jti", "exp": float64(331743679478)})
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.CreateScheme())
+			mockClient.WithObjects(tc.objs...)
+			k := kubernetes.NewEmpty(l).WithKubernetesClient(mockClient.Build())
 
-		b, err := mockNewBlocklist(ctx, l, k)
-		assert.NoError(t, err)
+			b, err := mockNewBlocklist(ctx, l, k)
+			assert.NoError(t, err)
 
-		blocked, err := b.IsBlocked(ctx, jwt)
-		assert.NoError(t, err)
-		assert.True(t, blocked)
-	})
+			blocked, err := b.IsBlocked(ctx, tc.token)
+			if tc.error != nil {
+				assert.Equal(t, tc.error, err)
+				return
+			}
 
-	t.Run("not blocked token in context", func(t *testing.T) {
-		ctx := context.Background()
-
-		b, err := mockNewBlocklist(ctx, l, k)
-		assert.NoError(t, err)
-
-		jwt := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"jti": "some-other-jti", "exp": float64(331743679478)})
-		blocked, err := b.IsBlocked(ctx, jwt)
-		assert.NoError(t, err)
-		assert.False(t, blocked)
-	})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.blocked, blocked)
+		})
+	}
 }
 
 func mockNewBlocklist(ctx context.Context, logger *zap.SugaredLogger, mockClient TokenStoreClient) (Blocklist, error) {

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -180,8 +180,12 @@ func TestIsBlocked(t *testing.T) {
 		},
 		{
 			// other error cases are covered by unit tests for specific functions
-			name:      "error parse passwordMtime",
-			token:     jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iat": float64(1847058325), "sub": "test:login", "iss": SessionManagerClaimsIssuer}), // ts is earlier than the password time
+			name: "error parse passwordMtime",
+			token: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"iat": float64(1847058325),
+				"sub": "test:login",
+				"iss": SessionManagerClaimsIssuer,
+			}), // ts is earlier than the password time
 			error:     errors.New(`parsing time "some weird string" as "2006-01-02T15:04:05Z07:00": cannot parse "some weird string" as "2006"`),
 			isBlocked: false,
 			usersFile: `test:


### PR DESCRIPTION
[![EVEREST-2210](https://badgen.net/badge/JIRA/EVEREST-2210/green)](https://jira.percona.com/browse/EVEREST-2210) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Is appears that original issuerUrl provided by user for OIDC configuration is not always the same as the one fetched from the OIDC provider's .well-known/openid-configuration (Microsoft Entra case). 
Need to add original issuer URL provided by user to Security-Policy headers as well, otherwise there will be issues with browser login using SSO.

[EVEREST-2210]: https://perconadev.atlassian.net/browse/EVEREST-2210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ