### PR TITLE
EVEREST-2208 - Fix E2E tests

### DIFF
--- a/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
+++ b/ui/apps/everest/.e2e/release/init-deploy.e2e.ts
@@ -189,7 +189,10 @@ const zephyrMap: Record<string, string> = {
 
         await test.step('Check db list and status', async () => {
           await page.goto('/databases');
-          await waitForStatus(page, clusterName, 'Initializing', 30000);
+          // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
+          if (size != 1 || db != 'psmdb') {
+            await waitForStatus(page, clusterName, 'Initializing', 30000);
+          }
           await waitForStatus(page, clusterName, 'Up', 720000);
         });
 
@@ -421,7 +424,10 @@ const zephyrMap: Record<string, string> = {
         page,
       }) => {
         await resumeDbCluster(page, clusterName);
-        await waitForStatus(page, clusterName, 'Initializing', 45000);
+        // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
+        if (size != 1 || db != 'psmdb') {
+          await waitForStatus(page, clusterName, 'Initializing', 45000);
+        }
         await waitForStatus(page, clusterName, 'Up', 600000);
       });
 
@@ -433,7 +439,10 @@ const zephyrMap: Record<string, string> = {
         if (size != 1 && db != 'postgresql') {
           await waitForStatus(page, clusterName, 'Stopping', 45000);
         }
-        await waitForStatus(page, clusterName, 'Initializing', 120000);
+        // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
+        if (size != 1 || db != 'psmdb') {
+          await waitForStatus(page, clusterName, 'Initializing', 120000);
+        }
         await waitForStatus(page, clusterName, 'Up', 600000);
       });
 
@@ -493,7 +502,10 @@ const zephyrMap: Record<string, string> = {
 
         await test.step('Wait for cluster status', async () => {
           await page.goto('databases');
-          await waitForStatus(page, clusterName, 'Initializing', 60000);
+          // TODO: try re-enable after fix for: https://perconadev.atlassian.net/browse/EVEREST-1693
+          if (size != 1 || db != 'psmdb') {
+            await waitForStatus(page, clusterName, 'Initializing', 60000);
+          }
           await waitForStatus(page, clusterName, 'Up', 300000);
         });
       });

--- a/ui/apps/everest/.e2e/release/restore-new-cluster.e2e.ts
+++ b/ui/apps/everest/.e2e/release/restore-new-cluster.e2e.ts
@@ -38,7 +38,7 @@ import {
   findRowAndClickActions,
 } from '@e2e/utils/table';
 import { clickCreateSchedule } from '@e2e/pr/db-cluster-details/utils';
-import { prepareTestDB, dropTestDB, queryTestDB } from '@e2e/utils/db-cmd-line';
+import { prepareTestDB, queryTestDB } from '@e2e/utils/db-cmd-line';
 import { getDbClusterAPI } from '@e2e/utils/db-cluster';
 import { shouldExecuteDBCombination } from '@e2e/utils/generic';
 
@@ -355,7 +355,10 @@ function getNextScheduleMinute(incrementMinutes: number): string {
 
         await test.step('Check restored DB list and status', async () => {
           await waitForStatus(page, restoredClusterName, 'Initializing', 15000);
-          await waitForStatus(page, restoredClusterName, 'Restoring', 600000);
+          if (db !== 'postgresql') {
+            await waitForStatus(page, restoredClusterName, 'Restoring', 600000);
+          }
+
           await waitForStatus(page, restoredClusterName, 'Up', 2400000);
         });
 

--- a/ui/apps/everest/.e2e/utils/db-cmd-line.ts
+++ b/ui/apps/everest/.e2e/utils/db-cmd-line.ts
@@ -118,7 +118,7 @@ export const queryMySQL = async (
   cluster: string,
   namespace: string,
   query: string,
-  retry: number = 1
+  retry: number = 2
 ): Promise<string> => {
   const password = await getPXCPassword(cluster, namespace);
   const clientPod = await getDBClientPod('mysql', 'db-client');
@@ -152,7 +152,7 @@ export const queryPSMDB = async (
   namespace: string,
   db: string,
   query: string,
-  retry: number = 1
+  retry: number = 2
 ): Promise<string> => {
   const password = await getPSMDBPassword(cluster, namespace);
   const clientPod = await getDBClientPod('psmdb', 'db-client');
@@ -191,7 +191,7 @@ export const queryPG = async (
   namespace: string,
   db: string,
   query: string,
-  retry: number = 1
+  retry: number = 2
 ): Promise<string> => {
   const password = await getPGPassword(cluster, namespace);
   const clientPod = await getDBClientPod('postgresql', 'db-client');


### PR DESCRIPTION
We reverted version of PSMDB operator so we need to remove checking for `Initializing` status for 1 node PSMDB databases.
Also we increased the retry number from 1 to 2 when querying database right after restore because immediately after restore it can fail once.