### PR TITLE
EVEREST-107 fix PMM usage in CI

### DIFF
--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -39,13 +39,14 @@ test('create/update/delete monitoring instance', async ({ request, page }) => {
     expect(created.type).toBe(data.type)
   })
 
-  await test.step('create another monitoring instance', async () => {
+  await test.step('create another monitoring instance with login and password', async () => {
     const data = {
       type: 'pmm',
       name: `${prefix}-pass`,
       url: `https://${process.env.PMM2_IP}`,
       pmm: {
-        apiKey: `${process.env.PMM2_API_KEY}`,
+        user: "admin",
+        password: "admin",
       },
       verifyTLS: false,
     }

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.33.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250806115327-b206083bb00f
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250801102351-5e60893d3d85
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250812102952-a4788eb1dc32
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250806115327-b206083bb00f h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250806115327-b206083bb00f/go.mod h1:fqf/M+zbnlSYYoditNBTBKwRrL0YaX3n3syKrEWOjLw=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe h1:CPO2T7ADauXJEXjwflAVYGRSZ/fKVVP12jE/Iy/1b7k=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe/go.mod h1:HRKf8nO4SqtNJ1oNzfY3THcwIsjGTWGBF3rNz1TwA9c=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250801102351-5e60893d3d85 h1:dPPdciaIy93AaILTx4lCNEyvLF+XGcY/mliSzw6tVOs=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250801102351-5e60893d3d85/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250812102952-a4788eb1dc32 h1:S66IMnpObHBHukCwMRNT7SOVxRhXuzFF9OuGlf6E4Zg=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250812102952-a4788eb1dc32/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20250313094841-676233c83e26 h1:hng2p9QPk/OxHVZEdsv+k0ByyHzTNSB0SWlVuuTxMjs=
 github.com/percona/percona-postgresql-operator v0.0.0-20250313094841-676233c83e26/go.mod h1:3D56UIi6Z0Z2gduNUuBcgjd1RNht3N8RKKmR9Wbfu4o=
 github.com/percona/percona-server-mongodb-operator v1.19.1 h1:lqIC7V80bZPJwjeYLYl/WA+QVQMHo193uEAx5zyIg84=

--- a/pkg/pmm/apikey.go
+++ b/pkg/pmm/apikey.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/percona/everest/cmd/config"
 )
 
 func newHTTPClient(insecure bool) *http.Client {
@@ -44,9 +42,6 @@ func CreatePMMApiKey(
 	hostname, apiKeyName, user, password string,
 	skipTLSVerify bool,
 ) (string, error) {
-	if config.Debug {
-		return "test-api-key", nil
-	}
 	apiKey := map[string]string{
 		"name": apiKeyName,
 		"role": "Admin",


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

CI used a debug build which provided a wrong PMM API key which lead to `"authorization failed, please provide the correct credentials"` failure in CI when using login-password

(Reported by the FE folks who also use PMM in CI)

[EVEREST-107]: https://perconadev.atlassian.net/browse/EVEREST-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ