### PR TITLE
EVEREST-2177 Remove initContainer from Tilt

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -344,8 +344,17 @@ def patch_everest_operator_debug(in_yaml):
           c['resources'] = None
   return encode_yaml_stream(objects)
 
+def patch_remove_operator_init_container(in_yaml):
+  print('Patching Everest operator deployment to delete init-containers')
+  objects = decode_yaml_stream(in_yaml)
+  for o in objects:
+    if o.get('kind') == 'Deployment' and o.get('metadata').get('name') == 'everest-operator':
+      o['spec']['template']['spec']['initContainers']= None
+  return encode_yaml_stream(objects)
+
 everest_yaml=patch_everest_debug(everest_yaml)
 everest_yaml=patch_everest_operator_debug(everest_yaml)
+everest_yaml=patch_remove_operator_init_container(everest_yaml)
 k8s_yaml(everest_yaml)
 
 #################################


### PR DESCRIPTION
EVEREST-2177 Remove initContainer from Tilt

initContainer uses the same `everest-operator` image as the main operator container but with the different entrypoint which is not supported by `docker_build_with_restart` which assumes a single entrypoint. So tilt was failing to run the everest-operator pod and now we patch the operator deployment to delete initContainer.

Related PRs:
- https://github.com/percona/everest-operator/pull/861
