### PR TITLE
EVEREST-1999 | update Everest CRDs uninstallation step

### DIFF
--- a/pkg/cli/uninstall/steps.go
+++ b/pkg/cli/uninstall/steps.go
@@ -71,7 +71,8 @@ func (u *Uninstall) deleteEverestCRDs(ctx context.Context) error {
 		return fmt.Errorf("failed to uninstall Helm chart: %w", err)
 	}
 	// If this chart was not found (i.e, if no upgrade was performed), that means the CRDs
-	// were installed via the everest chart. In that case, we will try to uninstall the CRDs explicitly.
+	// were installed via the everest chart. In that case, we will try to uninstall the CRDs explicitly,
+	// because Helm does not uninstall CRDs by default.
 	if !chartFound {
 		u.l.Infof("%s chart was not installed, deleting CRDs explicitly", helm.EverestCRDChartName)
 		return u.listAndDeleteEverestCRDs(ctx)


### PR DESCRIPTION
[![EVEREST-1999](https://badgen.net/badge/JIRA/EVEREST-1999/green)](https://jira.percona.com/browse/EVEREST-1999) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[EVEREST-1999]: https://perconadev.atlassian.net/browse/EVEREST-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

EVEREST-1999 moved the CRDs to a separate helm chart, however, the CLI uninstall logic was not updated to clean up this Helm release.