### PR TITLE
EVEREST-2283 - Disable retry in post upgrade test

### DIFF
--- a/ui/apps/everest/.e2e/upgrade/post-upgrade.e2e.ts
+++ b/ui/apps/everest/.e2e/upgrade/post-upgrade.e2e.ts
@@ -34,9 +34,10 @@ let upgradeClustersInfo: {
   upgradeVersion: string | null;
 }[] = [];
 
-test.describe('Post upgrade tests', { tag: '@post-upgrade' }, async () => {
-  test.describe.configure({ timeout: TIMEOUTS.FifteenMinutes });
+test.describe.configure({ retries: 0 });
+test.describe.configure({ timeout: TIMEOUTS.FifteenMinutes });
 
+test.describe('Post upgrade tests', { tag: '@post-upgrade' }, async () => {
   test.beforeAll(async ({ request }) => {
     token = await getTokenFromLocalStorage();
     [namespace] = await getNamespacesFn(token, request);


### PR DESCRIPTION
[![EVEREST-2283](https://badgen.net/badge/JIRA/EVEREST-2283/green)](https://jira.percona.com/browse/EVEREST-2283) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We seem to have it disabled in pre-upgrade tests, but not in post-upgrade tests. It should be disabled because it can give false positives.

[EVEREST-2283]: https://perconadev.atlassian.net/browse/EVEREST-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ