### PR TITLE
EVEREST-2303 | helm upgrade failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/operator-framework/api v0.33.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20250915164349-fa468a03bb16
-	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250915171327-b59190537b6c
+	github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250916100046-bc4e95eeff5c
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ github.com/percona/everest-operator v0.6.0-dev1.0.20250915164349-fa468a03bb16 h1
 github.com/percona/everest-operator v0.6.0-dev1.0.20250915164349-fa468a03bb16/go.mod h1:snqVkXAHOFv8Jd6mlMl6wneJPvTU7+1XZqRGPAudSIA=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe h1:CPO2T7ADauXJEXjwflAVYGRSZ/fKVVP12jE/Iy/1b7k=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20250327100109-3ca299246bfe/go.mod h1:HRKf8nO4SqtNJ1oNzfY3THcwIsjGTWGBF3rNz1TwA9c=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250915171327-b59190537b6c h1:85xpR7epYn7gRxTquIrAUWz1j4vNSEZE45p8U4iAVTc=
-github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250915171327-b59190537b6c/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250916100046-bc4e95eeff5c h1:+ibMIdRoqRMeGY7EfBAaMytHj0xrS8TKrpaJMYfyVQ4=
+github.com/percona/percona-helm-charts/charts/everest v0.0.0-20250916100046-bc4e95eeff5c/go.mod h1:j5Ci48Azwb4Xs4XvZQNfleWCn2uyiZywazklxNH1ut4=
 github.com/percona/percona-postgresql-operator v0.0.0-20250313094841-676233c83e26 h1:hng2p9QPk/OxHVZEdsv+k0ByyHzTNSB0SWlVuuTxMjs=
 github.com/percona/percona-postgresql-operator v0.0.0-20250313094841-676233c83e26/go.mod h1:3D56UIi6Z0Z2gduNUuBcgjd1RNht3N8RKKmR9Wbfu4o=
 github.com/percona/percona-server-mongodb-operator v1.19.1 h1:lqIC7V80bZPJwjeYLYl/WA+QVQMHo193uEAx5zyIg84=

--- a/pkg/cli/upgrade/steps.go
+++ b/pkg/cli/upgrade/steps.go
@@ -157,7 +157,8 @@ func (u *Upgrade) upgradeEverestDBNamespaceHelmChart(ctx context.Context, namesp
 
 	return installer.Upgrade(ctx, helm.UpgradeOptions{
 		DisableHooks: true,
-		ReuseValues:  true,
+		// This will preserve old values and use any new values from the chart.
+		ResetThenReuseValues: true,
 	})
 }
 


### PR DESCRIPTION
[![EVEREST-2303](https://badgen.net/badge/JIRA/EVEREST-2303/green)](https://jira.percona.com/browse/EVEREST-2303) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### Problem

Cannot perform upgrade using CLI:

```
:x: could not upgrade DB namespaces Helm charts: could not upgrade DB namespace 'everest-ui' Helm chart: template: everest-db-namespace/templates/hooks.yaml:1:94: executing "everest-db-namespace/templates/hooks.yaml" at <.Values.hooks.csvCleanup.image>: nil pointer evaluating interface {}.csvCleanup
:x:  Upgrading Helm chart
```

This issue was observed in `1.9.0-rc1`

### Cause

We added some new types of values in https://github.com/percona/percona-helm-charts/pull/636. But the DB chart release upgrade seems to be using `ReuseValues` which causes the new `hook` settings to evaluate to nil.

### Solution

Use `ResetThenReuseValues` instead

[EVEREST-2303]: https://perconadev.atlassian.net/browse/EVEREST-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ