### PR TITLE
Fix timeout in PITR test for backup deletion

### DIFF
--- a/ui/apps/everest/.e2e/release/pitr.e2e.ts
+++ b/ui/apps/everest/.e2e/release/pitr.e2e.ts
@@ -663,7 +663,7 @@ function getBackupStorage(): string {
             );
             await expect(page.getByLabel('Delete backup')).toBeVisible();
             await page.getByTestId('form-dialog-delete').click();
-            await waitForDelete(page, baseBackupName + `-${i}`, 30000);
+            await waitForDelete(page, baseBackupName + `-${i}`, 60000);
           }
         }
       });


### PR DESCRIPTION
It seems 30s is not enough for PXC backup deletion so this increases the timeout in PITR test.