### PR TITLE
Fix PITR test for PG

### DIFF
--- a/ui/apps/everest/.e2e/utils/db-wizard.ts
+++ b/ui/apps/everest/.e2e/utils/db-wizard.ts
@@ -77,9 +77,15 @@ export const goToLastStepByStepAndSubmit = async (
   waitMs?: number
 ) => {
   let createDbVisible = false;
+  let stepNr = 0;
   while (!createDbVisible) {
     if (waitMs) {
       await page.waitForTimeout(waitMs);
+    }
+    stepNr++;
+    if (stepNr == 3) {
+      await moveBack(page);
+      await moveForward(page);
     }
     await moveForward(page);
     const a = await page.getByTestId('db-wizard-submit-button').isVisible();


### PR DESCRIPTION
This is a workaround for the issue which is 99% visible with automatic test where in the backups screen when we create a new cluster from the PITR backup the PITR storage location is expected for PG, but the field is not visible so the create cluster button is disabled in the end.