### PR TITLE
chore: remove extra security vulnerability from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,3 @@ contact_links:
   - name: 🙋🏾 Generic question
     url: https://github.com/openeverest/openeverest/discussions/new
     about: If you need help debugging something or have a general question about OpenEverest
-
-  - name: 🔒 Report a Security Vulnerability
-    url: https://github.com/openeverest/openeverest/security/advisories/new
-    about: Please report security vulnerabilities privately here. Do not open a public issue.


### PR DESCRIPTION
## Description
This PR removes the extra security vulnerability option from the issue template to avoid any confusion since `SECURITY.md` has automatically created one.
Fix #1790 
