### PR TITLE
Trigger Homebrew tap update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,3 +378,12 @@ jobs:
           draft: true
           files: |
             dist/*
+
+      - name: Trigger Homebrew tap update
+        if: env.IS_RC == 0
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.TAP_REPO_TOKEN }}" \
+            https://api.github.com/repos/openeverest/homebrew-tap/dispatches \
+            -d "{\"event_type\":\"new-release\",\"client_payload\":{\"version\":\"$VERSION\"}}"


### PR DESCRIPTION
Add a step to trigger Homebrew tap update on release.

It triggers an update script in https://github.com/openeverest/homebrew-tap/tree/main/scripts