### PR TITLE
Do not watch `public.html` in tilt dev setup

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -644,7 +644,7 @@ local_resource(
         '{0}/api'.format(backend_dir),
         '{0}/cmd'.format(backend_dir),
         '{0}/pkg'.format(backend_dir),
-        '{0}/public'.format(backend_dir),
+        '{0}/public/dist/static'.format(backend_dir),
         '{0}/internal'.format(backend_dir),
     ],
     ignore=[


### PR DESCRIPTION
Currently tilt setup does not successfully complete. Possibly regression from #1908.

It seems `public/dist/index.html` is being created, then it triggers tilt build for `backend-build` then it modifies  `public/dist/index.html` and creates `backend-build` again, repeatedly. 

<img width="1555" height="462" alt="image" src="https://github.com/user-attachments/assets/32258b8c-e3bc-4043-9ed9-45cfc086c0d4" />

`backend-build` then triggers `everest-server-deploy` which redeploys server. During redeploy, you may not be able to use API.

Given `public/dist/index.html` is used for running server without building UI, I don't think watching `public/dist/index.html` is necessary. So this PR removes tilt to watching `public/dist/index.html`.