### PR TITLE
fix(copyright): update file diff command to use PR diff for accurate changes detection

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -29,9 +29,11 @@ jobs:
       - name: Collect changed source files
         id: changed
         run: |
+          # Use the PR diff, not a plain base-vs-head tree diff.
+          # This matches GitHub's "Files changed" tab and excludes files that differ
+          # only because the base branch moved forward after the feature branch split.
           FILES=$(git diff --name-only --diff-filter=ACM \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+           "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             | grep -E '\.(go|ts|tsx)$' || true)
 
           if [[ -z "$FILES" ]]; then


### PR DESCRIPTION
The problem of CI-flow:
The workflow was using a double-dot diff (`git diff base.sha head.sha`), which compares branch tips, while GitHub PRs use a triple-dot diff (`git diff base.sha...head.sha`) based on the merge-base.
As a result, CI picked up files changed in the base branch but not in the PR itself, leading to unrelated files appearing in header checks.