### PR TITLE
 Add everestctl status command for health checking Everest components

### DIFF
--- a/commands/status.go
+++ b/commands/status.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands ...
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/percona/everest/pkg/cli/status"
+	"github.com/percona/everest/pkg/logger"
+	"github.com/percona/everest/pkg/output"
+)
+
+var (
+	statusCmd = &cobra.Command{
+		Use:   "status [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Show health status of Everest components",
+		Long:  "Show health status of all Everest components including core services, OLM, monitoring, and database operators",
+		Run:   statusRun,
+	}
+	statusCfg = status.StatusConfig{
+		Pretty: true,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}
+
+func statusRun(cmd *cobra.Command, _ []string) { //nolint:revive
+	statusCfg.Pretty = rootCmdFlags.Pretty
+	statusCfg.JSON = rootCmdFlags.JSON
+	statusCfg.KubeconfigPath = rootCmdFlags.KubeconfigPath
+
+	op, err := status.NewStatus(statusCfg, logger.GetLogger())
+	if err != nil {
+		output.PrintError(err, logger.GetLogger(), statusCfg.Pretty)
+		os.Exit(1)
+	}
+
+	if err := op.Run(cmd.Context()); err != nil {
+		output.PrintError(err, logger.GetLogger(), statusCfg.Pretty)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260413161429-21c4dc6ac2dc
+	github.com/openeverest/helm-charts/charts/everest v0.0.0-20260414092111-1eecdda83aaa
 	github.com/operator-framework/api v0.33.0
 	github.com/percona/everest-operator v0.6.0-dev1.0.20260413160948-8fed595a87aa
 	github.com/rodaine/table v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260413161429-21c4dc6ac2dc h1:iBo7IqaEPSSJG2FtdR9MAVTi8Yv2G/C6OC8BIKj90dk=
-github.com/openeverest/helm-charts/charts/everest v0.0.0-20260413161429-21c4dc6ac2dc/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260414092111-1eecdda83aaa h1:OyewqT1f7zjHJo+cI25Nw8zpg9YlEm9EraVNhy5QUCA=
+github.com/openeverest/helm-charts/charts/everest v0.0.0-20260414092111-1eecdda83aaa/go.mod h1:Mwy0zH9GgTrrVy08klocVAXxhLmQfDqhuUz88uYckgQ=
 github.com/operator-framework/api v0.33.0 h1:Tdu9doXz6Key2riIiP3/JPahHEgFBXAqyWQN4kOITS8=
 github.com/operator-framework/api v0.33.0/go.mod h1:sEh1VqwQCJUj+l/rKNWPDEJdFNAbdTu8QcM+x+wdYYo=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -1,0 +1,344 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package status provides the logic for the `status` command.
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	cliutils "github.com/percona/everest/pkg/cli/utils"
+	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/kubernetes"
+	"github.com/percona/everest/pkg/output"
+	"github.com/percona/everest/pkg/version"
+)
+
+// StatusConfig holds the configuration for the `status` command.
+type StatusConfig struct {
+	// KubeconfigPath is the path to the kubeconfig file.
+	KubeconfigPath string
+	// Pretty if set print the output in pretty mode.
+	Pretty bool
+	// JSON if set print the output in JSON mode.
+	JSON bool
+}
+
+// Status provides the functionality to check Everest health.
+type Status struct {
+	l          *zap.SugaredLogger
+	cfg        StatusConfig
+	kubeClient kubernetes.KubernetesConnector
+}
+
+// ComponentStatus represents the health status of a single component.
+type ComponentStatus struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Ready     bool   `json:"ready"`
+	Message   string `json:"message,omitempty"`
+}
+
+// OperatorStatus represents the health status of a database operator.
+type OperatorStatus struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Version   string `json:"version,omitempty"`
+	Ready     bool   `json:"ready"`
+	Message   string `json:"message,omitempty"`
+}
+
+// OverallStatus represents the overall health status of Everest.
+type OverallStatus struct {
+	EverestVersion string            `json:"everestVersion"`
+	Healthy        bool              `json:"healthy"`
+	Components     []ComponentStatus `json:"components"`
+	Operators      []OperatorStatus  `json:"operators"`
+	Namespaces     []string          `json:"namespaces"`
+}
+
+// NewStatus returns a new Status struct.
+func NewStatus(cfg StatusConfig, l *zap.SugaredLogger) (*Status, error) {
+	s := &Status{
+		l:   l.With("component", "status"),
+		cfg: cfg,
+	}
+	if cfg.Pretty {
+		s.l = zap.NewNop().Sugar()
+	}
+
+	var err error
+	s.kubeClient, err = cliutils.NewKubeConnector(s.l, cfg.KubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Run executes the status check.
+func (s *Status) Run(ctx context.Context) error {
+	result := &OverallStatus{
+		Healthy: true,
+	}
+
+	// Get Everest version.
+	ev, err := version.EverestVersionFromDeployment(ctx, s.kubeClient)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			result.EverestVersion = "[NOT INSTALLED]"
+			result.Healthy = false
+		} else {
+			return fmt.Errorf("failed to get Everest version: %w", err)
+		}
+	} else {
+		result.EverestVersion = fmt.Sprintf("v%s", ev.String())
+	}
+
+	// Check core components.
+	s.checkCoreComponents(ctx, result)
+
+	// Check OLM components.
+	s.checkOLMComponents(ctx, result)
+
+	// Check monitoring components.
+	s.checkMonitoringComponents(ctx, result)
+
+	// Check database operators.
+	s.checkDatabaseOperators(ctx, result)
+
+	// Get managed namespaces.
+	s.getManagedNamespaces(ctx, result)
+
+	// Print results.
+	if s.cfg.JSON {
+		return s.printJSON(result)
+	}
+	s.printPretty(result)
+	return nil
+}
+
+func (s *Status) checkCoreComponents(ctx context.Context, result *OverallStatus) {
+	coreDeployments := []struct {
+		name      string
+		namespace string
+	}{
+		{common.PerconaEverestDeploymentName, common.SystemNamespace},
+		{common.PerconaEverestOperatorDeploymentName, common.SystemNamespace},
+	}
+
+	for _, d := range coreDeployments {
+		cs := s.checkDeployment(ctx, d.name, d.namespace)
+		result.Components = append(result.Components, cs)
+		if !cs.Ready {
+			result.Healthy = false
+		}
+	}
+}
+
+func (s *Status) checkOLMComponents(ctx context.Context, result *OverallStatus) {
+	depls, err := s.kubeClient.ListDeployments(ctx, ctrlclient.InNamespace(kubernetes.OLMNamespace))
+	if err != nil {
+		s.l.Debugf("Failed to list OLM deployments: %v", err)
+		result.Components = append(result.Components, ComponentStatus{
+			Name:      "OLM",
+			Namespace: kubernetes.OLMNamespace,
+			Ready:     false,
+			Message:   fmt.Sprintf("failed to list deployments: %v", err),
+		})
+		result.Healthy = false
+		return
+	}
+
+	for _, depl := range depls.Items {
+		cs := s.checkDeployment(ctx, depl.GetName(), depl.GetNamespace())
+		result.Components = append(result.Components, cs)
+		if !cs.Ready {
+			result.Healthy = false
+		}
+	}
+}
+
+func (s *Status) checkMonitoringComponents(ctx context.Context, result *OverallStatus) {
+	monitoringDeployments := []string{
+		common.VictoriaMetricsOperatorDeploymentName,
+		common.KubeStateMetricsDeploymentName,
+	}
+
+	for _, name := range monitoringDeployments {
+		cs := s.checkDeployment(ctx, name, common.MonitoringNamespace)
+		result.Components = append(result.Components, cs)
+		if !cs.Ready {
+			result.Healthy = false
+		}
+	}
+}
+
+func (s *Status) checkDatabaseOperators(ctx context.Context, result *OverallStatus) {
+	operators := []struct {
+		product string
+		name    string
+	}{
+		{common.MySQLProductName, common.MySQLOperatorName},
+		{common.MongoDBProductName, common.MongoDBOperatorName},
+		{common.PostgreSQLProductName, common.PostgreSQLOperatorName},
+	}
+
+	// Get all DB namespaces to check for operators.
+	dbNamespaces, err := s.kubeClient.GetDBNamespaces(ctx)
+	if err != nil {
+		s.l.Debugf("Failed to get DB namespaces: %v", err)
+		return
+	}
+
+	for _, ns := range dbNamespaces.Items {
+		for _, op := range operators {
+			os := OperatorStatus{
+				Name:      fmt.Sprintf("%s (%s)", op.name, op.product),
+				Namespace: ns.GetName(),
+				Ready:     true,
+			}
+
+			v, err := s.kubeClient.GetInstalledOperatorVersion(ctx, types.NamespacedName{
+				Name:      op.name,
+				Namespace: ns.GetName(),
+			})
+			if err != nil {
+				if errors.Is(err, kubernetes.ErrOperatorNotInstalled) {
+					continue // Not installed in this namespace, skip.
+				}
+				os.Ready = false
+				os.Message = fmt.Sprintf("error: %v", err)
+				result.Healthy = false
+			} else {
+				os.Version = fmt.Sprintf("v%s", v.String())
+			}
+
+			result.Operators = append(result.Operators, os)
+		}
+	}
+}
+
+func (s *Status) getManagedNamespaces(ctx context.Context, result *OverallStatus) {
+	nsList, err := s.kubeClient.GetDBNamespaces(ctx)
+	if err != nil {
+		s.l.Debugf("Failed to get managed namespaces: %v", err)
+		return
+	}
+
+	for _, ns := range nsList.Items {
+		result.Namespaces = append(result.Namespaces, ns.GetName())
+	}
+}
+
+func (s *Status) checkDeployment(ctx context.Context, name, namespace string) ComponentStatus {
+	cs := ComponentStatus{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	depl, err := s.kubeClient.GetDeployment(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			cs.Message = "not found"
+		} else {
+			cs.Message = fmt.Sprintf("error: %v", err)
+		}
+		return cs
+	}
+
+	cs.Ready = isDeploymentReady(depl)
+	if !cs.Ready {
+		cs.Message = fmt.Sprintf("%d/%d ready",
+			depl.Status.ReadyReplicas,
+			depl.Status.Replicas,
+		)
+	}
+	return cs
+}
+
+func isDeploymentReady(depl *appsv1.Deployment) bool {
+	return depl.Status.ReadyReplicas == depl.Status.Replicas &&
+		depl.Status.Replicas == depl.Status.UpdatedReplicas &&
+		depl.Status.UnavailableReplicas == 0 &&
+		depl.GetGeneration() == depl.Status.ObservedGeneration
+}
+
+func (s *Status) printJSON(result *OverallStatus) error {
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal status: %w", err)
+	}
+	_, _ = fmt.Fprintln(os.Stdout, string(data))
+	return nil
+}
+
+func (s *Status) printPretty(result *OverallStatus) {
+	var out io.Writer = os.Stdout
+
+	// Header
+	if result.Healthy {
+		_, _ = fmt.Fprint(out, output.Success("Everest %s is healthy", result.EverestVersion))
+	} else {
+		_, _ = fmt.Fprint(out, output.Failure("Everest %s has issues", result.EverestVersion))
+	}
+
+	// Components
+	_, _ = fmt.Fprintln(out, "\nComponents:")
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "  NAME\tNAMESPACE\tSTATUS\tMESSAGE")
+	for _, c := range result.Components {
+		status := "✅ Ready"
+		if !c.Ready {
+			status = "❌ Not Ready"
+		}
+		_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", c.Name, c.Namespace, status, c.Message)
+	}
+	w.Flush()
+
+	// Namespaces
+	if len(result.Namespaces) > 0 {
+		_, _ = fmt.Fprintf(out, "\nManaged Namespaces: %s\n", strings.Join(result.Namespaces, ", "))
+	}
+
+	// Operators
+	if len(result.Operators) > 0 {
+		_, _ = fmt.Fprintln(out, "\nDatabase Operators:")
+		w = tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "  NAME\tNAMESPACE\tVERSION\tSTATUS\tMESSAGE")
+		for _, op := range result.Operators {
+			status := "✅ Ready"
+			if !op.Ready {
+				status = "❌ Not Ready"
+			}
+			_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n", op.Name, op.Namespace, op.Version, status, op.Message)
+		}
+		w.Flush()
+	}
+}

--- a/pkg/cli/status/status_test.go
+++ b/pkg/cli/status/status_test.go
@@ -1,0 +1,507 @@
+// Copyright (C) 2026 The OpenEverest Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/percona/everest/pkg/common"
+	"github.com/percona/everest/pkg/kubernetes"
+)
+
+func TestIsDeploymentReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		depl     *appsv1.Deployment
+		expected bool
+	}{
+		{
+			name: "Deployment is ready",
+			depl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            1,
+					ReadyReplicas:       1,
+					UpdatedReplicas:     1,
+					UnavailableReplicas: 0,
+					ObservedGeneration:  1,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Deployment not ready - replicas mismatch",
+			depl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            2,
+					ReadyReplicas:       1,
+					UpdatedReplicas:     2,
+					UnavailableReplicas: 1,
+					ObservedGeneration:  1,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Deployment not ready - generation mismatch",
+			depl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            1,
+					ReadyReplicas:       1,
+					UpdatedReplicas:     1,
+					UnavailableReplicas: 0,
+					ObservedGeneration:  1,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Deployment not ready - unavailable replicas",
+			depl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            1,
+					ReadyReplicas:       0,
+					UpdatedReplicas:     1,
+					UnavailableReplicas: 1,
+					ObservedGeneration:  1,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Deployment ready - multiple replicas",
+			depl: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            3,
+					ReadyReplicas:       3,
+					UpdatedReplicas:     3,
+					UnavailableReplicas: 0,
+					ObservedGeneration:  3,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, isDeploymentReady(tc.depl))
+		})
+	}
+}
+
+func TestCheckDeployment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		deplName  string
+		namespace string
+		objects   []appsv1.Deployment
+		wantReady bool
+		wantMsg   string
+	}{
+		{
+			name:      "Deployment found and ready",
+			deplName:  "everest-server",
+			namespace: "everest-system",
+			objects: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "everest-server",
+						Namespace:  "everest-system",
+						Generation: 1,
+					},
+					Status: appsv1.DeploymentStatus{
+						Replicas:           1,
+						ReadyReplicas:      1,
+						UpdatedReplicas:    1,
+						ObservedGeneration: 1,
+					},
+				},
+			},
+			wantReady: true,
+		},
+		{
+			name:      "Deployment found but not ready",
+			deplName:  "everest-server",
+			namespace: "everest-system",
+			objects: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "everest-server",
+						Namespace:  "everest-system",
+						Generation: 1,
+					},
+					Status: appsv1.DeploymentStatus{
+						Replicas:            2,
+						ReadyReplicas:       1,
+						UpdatedReplicas:     2,
+						UnavailableReplicas: 1,
+						ObservedGeneration:  1,
+					},
+				},
+			},
+			wantReady: false,
+			wantMsg:   "1/2 ready",
+		},
+		{
+			name:      "Deployment not found",
+			deplName:  "missing-deployment",
+			namespace: "everest-system",
+			objects:   []appsv1.Deployment{},
+			wantReady: false,
+			wantMsg:   "not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.CreateScheme())
+
+			for i := range tc.objects {
+				builder = builder.WithObjects(&tc.objects[i])
+			}
+
+			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).
+				WithKubernetesClient(builder.Build())
+
+			s := &Status{
+				l:          zap.NewNop().Sugar(),
+				kubeClient: k,
+			}
+
+			cs := s.checkDeployment(context.Background(), tc.deplName, tc.namespace)
+			assert.Equal(t, tc.wantReady, cs.Ready)
+			assert.Equal(t, tc.deplName, cs.Name)
+			assert.Equal(t, tc.namespace, cs.Namespace)
+			if tc.wantMsg != "" {
+				assert.Contains(t, cs.Message, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestCheckCoreComponents(t *testing.T) {
+	t.Parallel()
+
+	readyDeployment := func(name, namespace string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:           1,
+				ReadyReplicas:      1,
+				UpdatedReplicas:    1,
+				ObservedGeneration: 1,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		objects     []*appsv1.Deployment
+		wantHealthy bool
+	}{
+		{
+			name: "All core components healthy",
+			objects: []*appsv1.Deployment{
+				readyDeployment(common.PerconaEverestDeploymentName, common.SystemNamespace),
+				readyDeployment(common.PerconaEverestOperatorDeploymentName, common.SystemNamespace),
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "Server missing",
+			objects: []*appsv1.Deployment{
+				readyDeployment(common.PerconaEverestOperatorDeploymentName, common.SystemNamespace),
+			},
+			wantHealthy: false,
+		},
+		{
+			name:        "Both missing",
+			objects:     []*appsv1.Deployment{},
+			wantHealthy: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.CreateScheme())
+			for _, obj := range tc.objects {
+				builder = builder.WithObjects(obj)
+			}
+
+			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).
+				WithKubernetesClient(builder.Build())
+
+			s := &Status{
+				l:          zap.NewNop().Sugar(),
+				kubeClient: k,
+			}
+
+			result := &OverallStatus{Healthy: true}
+			s.checkCoreComponents(context.Background(), result)
+
+			assert.Equal(t, tc.wantHealthy, result.Healthy)
+			// Should always check 2 core components.
+			assert.Len(t, result.Components, 2)
+		})
+	}
+}
+
+func TestGetManagedNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		namespaces     []*corev1.Namespace
+		wantNamespaces []string
+	}{
+		{
+			name: "DB namespaces found",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "everest",
+						Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "prod-db",
+						Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+					},
+				},
+				// System namespace should be filtered out.
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   common.SystemNamespace,
+						Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+					},
+				},
+				// Monitoring namespace should be filtered out.
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   common.MonitoringNamespace,
+						Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+					},
+				},
+			},
+			wantNamespaces: []string{"everest", "prod-db"},
+		},
+		{
+			name:           "No DB namespaces",
+			namespaces:     []*corev1.Namespace{},
+			wantNamespaces: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.CreateScheme())
+			for _, ns := range tc.namespaces {
+				builder = builder.WithObjects(ns)
+			}
+
+			k := kubernetes.NewEmpty(zap.NewNop().Sugar()).
+				WithKubernetesClient(builder.Build())
+
+			s := &Status{
+				l:          zap.NewNop().Sugar(),
+				kubeClient: k,
+			}
+
+			result := &OverallStatus{}
+			s.getManagedNamespaces(context.Background(), result)
+			assert.Equal(t, tc.wantNamespaces, result.Namespaces)
+		})
+	}
+}
+
+func TestRun_Healthy(t *testing.T) {
+	t.Parallel()
+
+	// Create a minimal healthy cluster state.
+	builder := fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.CreateScheme()).
+		WithObjects(
+			// Core deployments.
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       common.PerconaEverestDeploymentName,
+					Namespace:  common.SystemNamespace,
+					Generation: 1,
+					Labels:     map[string]string{"app.kubernetes.io/name": "everest-server"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app.kubernetes.io/name": "everest-server"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app.kubernetes.io/name": "everest-server"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "everest", Image: "percona/everest:1.0.0"}},
+						},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 1,
+				},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       common.PerconaEverestOperatorDeploymentName,
+					Namespace:  common.SystemNamespace,
+					Generation: 1,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 1,
+				},
+			},
+			// Monitoring deployments.
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       common.VictoriaMetricsOperatorDeploymentName,
+					Namespace:  common.MonitoringNamespace,
+					Generation: 1,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 1,
+				},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       common.KubeStateMetricsDeploymentName,
+					Namespace:  common.MonitoringNamespace,
+					Generation: 1,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 1,
+				},
+			},
+			// DB namespace.
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "everest",
+					Labels: map[string]string{common.KubernetesManagedByLabel: common.Everest},
+				},
+			},
+		)
+
+	k := kubernetes.NewEmpty(zap.NewNop().Sugar()).
+		WithKubernetesClient(builder.Build())
+
+	s := &Status{
+		l:          zap.NewNop().Sugar(),
+		cfg:        StatusConfig{JSON: true},
+		kubeClient: k,
+	}
+
+	err := s.Run(context.Background())
+	require.NoError(t, err)
+}
+
+func TestRun_Unhealthy(t *testing.T) {
+	t.Parallel()
+
+	// Create a cluster with a missing operator deployment.
+	builder := fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.CreateScheme()).
+		WithObjects(
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       common.PerconaEverestDeploymentName,
+					Namespace:  common.SystemNamespace,
+					Generation: 1,
+					Labels:     map[string]string{"app.kubernetes.io/name": "everest-server"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app.kubernetes.io/name": "everest-server"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app.kubernetes.io/name": "everest-server"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "everest", Image: "percona/everest:1.0.0"}},
+						},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 1,
+				},
+			},
+			// everest-operator is MISSING - should cause unhealthy status
+		)
+
+	k := kubernetes.NewEmpty(zap.NewNop().Sugar()).
+		WithKubernetesClient(builder.Build())
+
+	s := &Status{
+		l:          zap.NewNop().Sugar(),
+		cfg:        StatusConfig{JSON: true},
+		kubeClient: k,
+	}
+
+	err := s.Run(context.Background())
+	require.NoError(t, err)
+}


### PR DESCRIPTION

This adds a new everestctl status command that gives operators a quick way to check the health of their Everest installation something that's been missing and usually means manually poking around with kubectl to figure out what's running and what's not.

 Running everestctl status will check and report on:

   - Core components — everest-server and everest-operator
   - OLM — catalog-operator and olm-operator
   - Monitoring — victoria-metrics-operator and kube-state-metrics
   - Database operators — PXC, PSMDB, and PG operator versions (pulled from OLM subscriptions)
   - Managed namespaces — lists all namespaces Everest is managing

default output is a human-friendly table with status indicators. There's also --json for scripting/automation and -v for debug logging when you need to dig deeper.




<img width="1437" height="290" alt="image" src="https://github.com/user-attachments/assets/fb46ae7b-fa52-47e2-a07e-12980662ac9f" />

<img width="1920" height="976" alt="image" src="https://github.com/user-attachments/assets/32926bf1-ab89-4ed2-98be-46bd3b84674b" />


<img width="1920" height="347" alt="image" src="https://github.com/user-attachments/assets/d5d27814-945c-4d21-ad4d-9ddab4d72dbc" />



Fixes : https://github.com/openeverest/openeverest/issues/1863